### PR TITLE
feat: add flux dapp integration

### DIFF
--- a/packages/effects/src/dapps/flux/constants.ts
+++ b/packages/effects/src/dapps/flux/constants.ts
@@ -1,0 +1,30 @@
+export const FluxConstants = {
+  receiptResourceAddress:
+    "resource_rdx1ntz3kr363rnnf8rjkf7hddf8hrhuu8aqmg5g6ufwxm86anxrqhvtxp",
+  fusdResourceAddress:
+    "resource_rdx1t49wa75gve8ehvejr760g3pgvkawsgsgq0u3kh7vevzk0g0cnsmscq",
+  logicComponentAddress:
+    "component_rdx1czgv2hx5lq4v5tjm32u69s5dw8ja0d4qeau2y5vktvaxlrmsfdy08u",
+  xrdKvsAddress:
+    "internal_keyvaluestore_rdx1kpp4hem8mtfstuyff2qsamsu5frup0280txndrmhzezngeqa37yxhc",
+  lsulpKvsAddress:
+    "internal_keyvaluestore_rdx1kzmrvytjphqf78dvkhe4h6myg2r2ycln20qzxkee8ggmej6jf5q4ew",
+  collaterals: {
+    xrd: {
+      collateralAddress:
+        "resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd",
+      stabilityPoolAddress:
+        "pool_rdx1c5nzge2kpylwrtls7ydhnd03vs5f7w8w0jhzh99x82mw660war8y77",
+      stabilityPoolTokenAddress:
+        "resource_rdx1tk6gnvp5tmxqdr5zppuu50p2q9uvv89q2gyz432ukrh5md7ft4xesr",
+    },
+    lsulp: {
+      collateralAddress:
+        "resource_rdx1thksg5ng70g9mmy9ne7wz0sc7auzrrwy7fmgcxzel2gvp8pj0xxfmf",
+      stabilityPoolAddress:
+        "pool_rdx1c540e9ytpktwpqrq808xz3r0a8qxm2plrt4e5u5ecllzjcavrc9h8m",
+      stabilityPoolTokenAddress:
+        "resource_rdx1tksgc3j8ylrjjqgtny3l4dsfnpepch32hndyk20uptplqk8zuezk0z",
+    },
+  },
+} as const;

--- a/packages/effects/src/dapps/flux/constants.ts
+++ b/packages/effects/src/dapps/flux/constants.ts
@@ -1,3 +1,6 @@
+import { CaviarNineConstants } from "../caviarnine/constants";
+import { Assets } from "../../assets/constants";
+
 export const FluxConstants = {
   receiptResourceAddress:
     "resource_rdx1ntz3kr363rnnf8rjkf7hddf8hrhuu8aqmg5g6ufwxm86anxrqhvtxp",
@@ -11,16 +14,14 @@ export const FluxConstants = {
     "internal_keyvaluestore_rdx1kzmrvytjphqf78dvkhe4h6myg2r2ycln20qzxkee8ggmej6jf5q4ew",
   collaterals: {
     xrd: {
-      collateralAddress:
-        "resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd",
+      collateralAddress: Assets.Fungible.XRD,
       stabilityPoolAddress:
         "pool_rdx1c5nzge2kpylwrtls7ydhnd03vs5f7w8w0jhzh99x82mw660war8y77",
       stabilityPoolTokenAddress:
         "resource_rdx1tk6gnvp5tmxqdr5zppuu50p2q9uvv89q2gyz432ukrh5md7ft4xesr",
     },
     lsulp: {
-      collateralAddress:
-        "resource_rdx1thksg5ng70g9mmy9ne7wz0sc7auzrrwy7fmgcxzel2gvp8pj0xxfmf",
+      collateralAddress: CaviarNineConstants.LSULP.resourceAddress,
       stabilityPoolAddress:
         "pool_rdx1c540e9ytpktwpqrq808xz3r0a8qxm2plrt4e5u5ecllzjcavrc9h8m",
       stabilityPoolTokenAddress:

--- a/packages/effects/src/dapps/flux/getFluxCdps.test.ts
+++ b/packages/effects/src/dapps/flux/getFluxCdps.test.ts
@@ -1,0 +1,96 @@
+import { describe, it } from "vitest";
+import { Effect, Layer } from "effect";
+import { GatewayApiClientLive } from "../../gateway/gatewayApiClient";
+import { GetEntityDetailsServiceLive } from "../../gateway/getEntityDetails";
+import { GetLedgerStateLive } from "../../gateway/getLedgerState";
+
+import { EntityFungiblesPageLive } from "../../gateway/entityFungiblesPage";
+
+import { GetFluxCdpsService, GetFluxCdpsLive } from "./getFluxCdps";
+import { GetNonFungibleBalanceLive } from "../../gateway/getNonFungibleBalance";
+import { EntityNonFungiblesPageLive } from "../../gateway/entityNonFungiblesPage";
+import { EntityNonFungibleDataLive } from "../../gateway/entityNonFungiblesData";
+import { KeyValueStoreDataLive } from "../../gateway/keyValueStoreData";
+import { KeyValueStoreKeysLive } from "../../gateway/keyValueStoreKeys";
+
+const gatewayApiClientLive = GatewayApiClientLive;
+
+const getEntityDetailsServiceLive = GetEntityDetailsServiceLive.pipe(
+  Layer.provide(gatewayApiClientLive)
+);
+
+const getLedgerStateLive = GetLedgerStateLive.pipe(
+  Layer.provide(gatewayApiClientLive)
+);
+
+const entityFungiblesPageServiceLive = EntityFungiblesPageLive.pipe(
+  Layer.provide(gatewayApiClientLive)
+);
+
+const entityNonFungiblesPageServiceLive = EntityNonFungiblesPageLive.pipe(
+  Layer.provide(gatewayApiClientLive)
+);
+
+const entityNonFungibleDataServiceLive = EntityNonFungibleDataLive.pipe(
+  Layer.provide(gatewayApiClientLive)
+);
+
+const keyValueStoreKeysServiceLive = KeyValueStoreKeysLive.pipe(
+  Layer.provide(gatewayApiClientLive)
+);
+
+const keyValueStoreDataServiceLive = KeyValueStoreDataLive.pipe(
+  Layer.provide(gatewayApiClientLive)
+);
+
+const getNonFungibleBalanceLive = GetNonFungibleBalanceLive.pipe(
+  Layer.provide(getEntityDetailsServiceLive),
+  Layer.provide(gatewayApiClientLive),
+  Layer.provide(entityFungiblesPageServiceLive),
+  Layer.provide(entityNonFungiblesPageServiceLive),
+  Layer.provide(entityNonFungibleDataServiceLive),
+  Layer.provide(getLedgerStateLive)
+);
+
+const getFluxCdpsLive = GetFluxCdpsLive.pipe(
+  Layer.provide(getNonFungibleBalanceLive),
+  Layer.provide(entityNonFungiblesPageServiceLive),
+  Layer.provide(entityNonFungibleDataServiceLive),
+  Layer.provide(keyValueStoreKeysServiceLive),
+  Layer.provide(keyValueStoreDataServiceLive)
+);
+
+describe("GetFluxCdpsService", () => {
+  it("should get flux CDP positions", async () => {
+    const program = Effect.provide(
+      Effect.gen(function* () {
+        const getFluxCdps = yield* GetFluxCdpsService;
+
+        return yield* getFluxCdps({
+          accountAddresses: [
+            "account_rdx12xl2meqtelz47mwp3nzd72jkwyallg5yxr9hkc75ac4qztsxulfpew",
+            "account_rdx16y4gqnchvxeszcpswg2zldgsle6uqvnl0znerne70tw9535njhkgzk",
+            "account_rdx168nr5dwmll4k2x5apegw5dhrpejf3xac7khjhgjqyg4qddj9tg9v4d", // random account I found on the dashboard lol
+          ],
+          at_ledger_state: {
+            state_version: 302444078,
+          },
+        });
+      }),
+      Layer.mergeAll(
+        getFluxCdpsLive,
+        gatewayApiClientLive,
+        getNonFungibleBalanceLive,
+        entityFungiblesPageServiceLive,
+        entityNonFungiblesPageServiceLive,
+        entityNonFungibleDataServiceLive,
+        keyValueStoreKeysServiceLive,
+        keyValueStoreDataServiceLive,
+        getLedgerStateLive
+      )
+    );
+
+    const result = await Effect.runPromise(program);
+    console.log(JSON.stringify(result, null, 2));
+  });
+});

--- a/packages/effects/src/dapps/flux/getFluxCdps.ts
+++ b/packages/effects/src/dapps/flux/getFluxCdps.ts
@@ -163,14 +163,14 @@ export const GetFluxCdpsLive = Layer.effect(
         const [xrdInterestData, lsulpInterestData] = yield* Effect.all([
           keyValueStoreDataService({
             key_value_store_address: FluxConstants.xrdKvsAddress,
-            keys: xrdKeys.items.map((k: any) => ({
+            keys: xrdKeys.items.map((k) => ({
               key_json: k.key.programmatic_json,
             })),
             at_ledger_state: input.at_ledger_state,
           }),
           keyValueStoreDataService({
             key_value_store_address: FluxConstants.lsulpKvsAddress,
-            keys: lsulpKeys.items.map((k: any) => ({
+            keys: lsulpKeys.items.map((k) => ({
               key_json: k.key.programmatic_json,
             })),
             at_ledger_state: input.at_ledger_state,
@@ -206,13 +206,15 @@ export const GetFluxCdpsLive = Layer.effect(
               ? xrdInterestData.entries
               : lsulpInterestData.entries;
 
-          const interestInfo = interestData.find((entry: any) => {
+          const interestInfo = interestData.find((entry) => {
             const nodeData = entry.value.programmatic_json;
-            return (
-              nodeData &&
-              nodeData.kind === "Tuple" &&
-              new BigNumber(nodeData.fields[0].value).isEqualTo(interestRate)
-            );
+            if (nodeData.kind === "Tuple") {
+              const tupleFields = nodeData.fields;
+              if (tupleFields[0] && tupleFields[0].kind === "Decimal") {
+                const interestRateValue = new BigNumber(tupleFields[0].value);
+                return interestRateValue.isEqualTo(interestRate);
+              }
+            }
           });
 
           let realDebt = poolDebt;

--- a/packages/effects/src/dapps/flux/getFluxCdps.ts
+++ b/packages/effects/src/dapps/flux/getFluxCdps.ts
@@ -1,0 +1,282 @@
+import { Context, Effect, Layer } from "effect";
+import { BigNumber } from "bignumber.js";
+
+import { GatewayApiClientService } from "../../gateway/gatewayApiClient";
+import type { EntityFungiblesPageService } from "../../gateway/entityFungiblesPage";
+import type { GetLedgerStateService } from "../../gateway/getLedgerState";
+import type {
+  EntityNotFoundError,
+  GatewayError,
+  InvalidInputError,
+} from "../../gateway/errors";
+import { GetNonFungibleBalanceService } from "../../gateway/getNonFungibleBalance";
+import type { EntityNonFungiblesPageService } from "../../gateway/entityNonFungiblesPage";
+import { FluxConstants } from "./constants";
+import { CdpNftData } from "./schemas";
+import type { SborError } from "sbor-ez-mode";
+import { GetEntityDetailsError } from "../../gateway/getEntityDetails";
+import type { AtLedgerState } from "../../gateway/schemas";
+import { EntityNonFungibleDataService } from "../../gateway/entityNonFungiblesData";
+import { KeyValueStoreDataService } from "../../gateway/keyValueStoreData";
+import { KeyValueStoreKeysService } from "../../gateway/keyValueStoreKeys";
+
+export class FluxParseSborError {
+  readonly _tag = "FluxParseSborError";
+  constructor(readonly error: SborError) {}
+}
+
+export class InvalidFluxReceiptItemError extends Error {
+  readonly _tag = "InvalidFluxReceiptItemError";
+}
+
+export type GetFluxCdpsServiceInput = {
+  accountAddresses: string[];
+  at_ledger_state: AtLedgerState;
+};
+
+export type FluxCdpPosition = {
+  nft: {
+    resourceAddress: ResourceAddress;
+    localId: string;
+  };
+  collateralAddress: string;
+  collateralAmount: string;
+  realDebt: string;
+  poolDebt: string;
+  collateralFusdRatio: string;
+  interest: string;
+  lastInterestChange: string;
+  status: string;
+  privilegedBorrower: string | null;
+};
+
+export type GetFluxCdpsServiceOutput = {
+  items: {
+    accountAddress: AccountAddress;
+    cdpPositions: FluxCdpPosition[];
+  }[];
+};
+
+export class GetFluxCdpsService extends Context.Tag("GetFluxCdpsService")<
+  GetFluxCdpsService,
+  (input: {
+    accountAddresses: string[];
+    at_ledger_state: AtLedgerState;
+  }) => Effect.Effect<
+    GetFluxCdpsServiceOutput,
+    | GetEntityDetailsError
+    | EntityNotFoundError
+    | InvalidInputError
+    | GatewayError
+    | FluxParseSborError
+    | InvalidFluxReceiptItemError,
+    | GetNonFungibleBalanceService
+    | GatewayApiClientService
+    | EntityFungiblesPageService
+    | GetLedgerStateService
+    | EntityNonFungiblesPageService
+    | EntityNonFungibleDataService
+    | KeyValueStoreDataService
+    | KeyValueStoreKeysService
+  >
+>() {}
+
+type AccountAddress = string;
+type ResourceAddress = string;
+
+export const GetFluxCdpsLive = Layer.effect(
+  GetFluxCdpsService,
+  Effect.gen(function* () {
+    const getNonFungibleBalanceService = yield* GetNonFungibleBalanceService;
+    const entityNonFungibleDataService = yield* EntityNonFungibleDataService;
+    const keyValueStoreKeysService = yield* KeyValueStoreKeysService;
+    const keyValueStoreDataService = yield* KeyValueStoreDataService;
+
+    return (input) => {
+      return Effect.gen(function* () {
+        const accountCdpMap = new Map<AccountAddress, FluxCdpPosition[]>();
+
+        // First get all CDP NFT IDs for each account
+        const result = yield* getNonFungibleBalanceService({
+          addresses: input.accountAddresses,
+          at_ledger_state: input.at_ledger_state,
+          options: {
+            non_fungible_include_nfids: true,
+          },
+        }).pipe(Effect.withSpan("getNonFungibleBalanceService"));
+
+        // Collect all NFT IDs
+        const allNftIds: string[] = [];
+        const accountNftMap = new Map<string, string[]>();
+
+        for (const account of result.items) {
+          const nftIds: string[] = [];
+
+          const fluxReceipts = account.nonFungibleResources.filter(
+            (resource) =>
+              resource.resourceAddress === FluxConstants.receiptResourceAddress
+          );
+
+          for (const fluxReceipt of fluxReceipts) {
+            for (const fluxReceiptItem of fluxReceipt.items) {
+              nftIds.push(fluxReceiptItem.id);
+              allNftIds.push(fluxReceiptItem.id);
+            }
+          }
+
+          accountNftMap.set(account.address, nftIds);
+        }
+
+        if (allNftIds.length === 0) {
+          return {
+            items: input.accountAddresses.map((address) => ({
+              accountAddress: address,
+              cdpPositions: [],
+            })),
+          };
+        }
+
+        // Get NFT data for all CDPs at specific state version
+        const nftDataResults = yield* Effect.all(
+          allNftIds.map((nftId) =>
+            entityNonFungibleDataService({
+              resource_address: FluxConstants.receiptResourceAddress,
+              non_fungible_ids: [nftId],
+              at_ledger_state: input.at_ledger_state,
+            })
+          )
+        );
+
+        // Get interest rate keys from both KVS
+        const [xrdKeys, lsulpKeys] = yield* Effect.all([
+          keyValueStoreKeysService({
+            key_value_store_address: FluxConstants.xrdKvsAddress,
+            at_ledger_state: input.at_ledger_state,
+          }),
+          keyValueStoreKeysService({
+            key_value_store_address: FluxConstants.lsulpKvsAddress,
+            at_ledger_state: input.at_ledger_state,
+          }),
+        ]);
+
+        // Get interest rate data from both KVS
+        const [xrdInterestData, lsulpInterestData] = yield* Effect.all([
+          keyValueStoreDataService({
+            key_value_store_address: FluxConstants.xrdKvsAddress,
+            keys: xrdKeys.items.map((k: any) => ({
+              key_json: k.key.programmatic_json,
+            })),
+            at_ledger_state: input.at_ledger_state,
+          }),
+          keyValueStoreDataService({
+            key_value_store_address: FluxConstants.lsulpKvsAddress,
+            keys: lsulpKeys.items.map((k: any) => ({
+              key_json: k.key.programmatic_json,
+            })),
+            at_ledger_state: input.at_ledger_state,
+          }),
+        ]);
+
+        // Process CDP data
+        const cdps: FluxCdpPosition[] = [];
+
+        for (let i = 0; i < allNftIds.length; i++) {
+          const nftId = allNftIds[i];
+          const nftData = nftDataResults[i];
+
+          if (!nftData.non_fungible_ids[0]?.data?.programmatic_json) continue;
+
+          const parsed = CdpNftData.safeParse(
+            nftData.non_fungible_ids[0].data.programmatic_json
+          );
+
+          if (parsed.isErr()) {
+            continue; // Skip invalid data
+          }
+
+          const cdpNftData = parsed.value;
+          const interestRate = new BigNumber(cdpNftData.interest);
+          const poolDebt = new BigNumber(cdpNftData.pool_debt);
+          const collateralAddress = cdpNftData.collateral_address;
+
+          // Find matching interest rate info
+          const interestData =
+            collateralAddress ===
+            FluxConstants.collaterals.xrd.collateralAddress
+              ? xrdInterestData.entries
+              : lsulpInterestData.entries;
+
+          const interestInfo = interestData.find((entry: any) => {
+            const nodeData = entry.value.programmatic_json;
+            return (
+              nodeData &&
+              nodeData.kind === "Tuple" &&
+              new BigNumber(nodeData.fields[0].value).isEqualTo(interestRate)
+            );
+          });
+
+          let realDebt = poolDebt;
+          if (interestInfo) {
+            const nodeData = interestInfo.value.programmatic_json;
+            if (nodeData.kind === "Tuple") {
+              const tupleFields = nodeData.fields;
+              if (tupleFields[1] && tupleFields[1].kind === "Tuple") {
+                const innerFields = tupleFields[1].fields;
+                if (
+                  innerFields[0].kind === "Decimal" &&
+                  innerFields[1].kind === "Decimal"
+                ) {
+                  const totalPoolDebt = new BigNumber(innerFields[0].value);
+                  const realDebtValue = new BigNumber(innerFields[1].value);
+                  realDebt = realDebtValue
+                    .dividedBy(totalPoolDebt)
+                    .multipliedBy(poolDebt);
+                }
+              }
+            }
+          }
+
+          const privilegedBorrower =
+            cdpNftData.privileged_borrower.variant === "Some"
+              ? cdpNftData.privileged_borrower.value
+              : null;
+
+          cdps.push({
+            nft: {
+              resourceAddress: FluxConstants.receiptResourceAddress,
+              localId: nftId,
+            },
+            collateralAddress: cdpNftData.collateral_address,
+            collateralAmount: cdpNftData.collateral_amount,
+            poolDebt: cdpNftData.pool_debt,
+            realDebt: realDebt.toString(),
+            collateralFusdRatio: cdpNftData.collateral_fusd_ratio,
+            interest: cdpNftData.interest,
+            lastInterestChange: cdpNftData.last_interest_change.toString(),
+            status: cdpNftData.status.variant,
+            privilegedBorrower,
+          });
+        }
+
+        // Map CDPs back to accounts
+        for (const [accountAddress, nftIds] of accountNftMap.entries()) {
+          const accountCdps = cdps.filter((cdp) =>
+            nftIds.includes(cdp.nft.localId)
+          );
+          accountCdpMap.set(accountAddress, accountCdps);
+        }
+
+        const items = Array.from(accountCdpMap.entries()).map(
+          ([accountAddress, value]) => ({
+            accountAddress,
+            cdpPositions: value,
+          })
+        );
+
+        return {
+          items,
+        };
+      });
+    };
+  })
+);

--- a/packages/effects/src/dapps/flux/getFluxReservoir.test.ts
+++ b/packages/effects/src/dapps/flux/getFluxReservoir.test.ts
@@ -1,0 +1,83 @@
+import { describe, it } from "vitest";
+import { Effect, Layer } from "effect";
+
+import { GatewayApiClientLive } from "../../gateway/gatewayApiClient";
+import { GetEntityDetailsServiceLive } from "../../gateway/getEntityDetails";
+import {
+  GetLedgerStateLive,
+  GetLedgerStateService,
+} from "../../gateway/getLedgerState";
+import { GetFungibleBalanceLive } from "../../gateway/getFungibleBalance";
+import { EntityFungiblesPageLive } from "../../gateway/entityFungiblesPage";
+import {
+  GetFluxReservoirLive,
+  GetFluxReservoirService,
+} from "./getFluxReservoir";
+
+const gatewayApiClientLive = GatewayApiClientLive;
+
+const getEntityDetailsServiceLive = GetEntityDetailsServiceLive.pipe(
+  Layer.provide(gatewayApiClientLive)
+);
+
+const getLedgerStateLive = GetLedgerStateLive.pipe(
+  Layer.provide(gatewayApiClientLive)
+);
+
+const entityFungiblesPageServiceLive = EntityFungiblesPageLive.pipe(
+  Layer.provide(gatewayApiClientLive)
+);
+
+const getFungibleBalanceLive = GetFungibleBalanceLive.pipe(
+  Layer.provide(getEntityDetailsServiceLive),
+  Layer.provide(gatewayApiClientLive),
+  Layer.provide(entityFungiblesPageServiceLive),
+  Layer.provide(getLedgerStateLive)
+);
+
+const getFluxReservoirLive = GetFluxReservoirLive.pipe(
+  Layer.provide(getFungibleBalanceLive),
+  Layer.provide(gatewayApiClientLive),
+  Layer.provide(getLedgerStateLive)
+);
+
+describe("GetFluxReservoirService", () => {
+  it("should get flux reservoir positions", async () => {
+    const program = Effect.provide(
+      Effect.gen(function* () {
+        const getFluxReservoir = yield* GetFluxReservoirService;
+        const getLedgerState = yield* GetLedgerStateService;
+
+        const state = yield* getLedgerState({
+          at_ledger_state: {
+            timestamp: new Date(),
+          },
+        });
+
+        console.log(JSON.stringify(state, null, 2));
+
+        return yield* getFluxReservoir({
+          accountAddresses: [
+            "account_rdx12xl2meqtelz47mwp3nzd72jkwyallg5yxr9hkc75ac4qztsxulfpew",
+            "account_rdx16y4gqnchvxeszcpswg2zldgsle6uqvnl0znerne70tw9535njhkgzk",
+            "account_rdx168nr5dwmll4k2x5apegw5dhrpejf3xac7khjhgjqyg4qddj9tg9v4d", // random account I found on the dashboard lol
+          ],
+          at_ledger_state: {
+            state_version: state.state_version,
+          },
+        });
+      }),
+      Layer.mergeAll(
+        gatewayApiClientLive,
+        getFungibleBalanceLive,
+        entityFungiblesPageServiceLive,
+        getLedgerStateLive,
+        getFluxReservoirLive
+      )
+    );
+
+    const result = await Effect.runPromise(program);
+
+    console.log(JSON.stringify(result, null, 2));
+  });
+});

--- a/packages/effects/src/dapps/flux/getFluxReservoir.ts
+++ b/packages/effects/src/dapps/flux/getFluxReservoir.ts
@@ -1,0 +1,229 @@
+import { Context, Effect, Layer } from "effect";
+import { BigNumber } from "bignumber.js";
+
+import { GatewayApiClientService } from "../../gateway/gatewayApiClient";
+import type { EntityFungiblesPageService } from "../../gateway/entityFungiblesPage";
+import type { GetLedgerStateService } from "../../gateway/getLedgerState";
+import type {
+  EntityNotFoundError,
+  GatewayError,
+  InvalidInputError,
+} from "../../gateway/errors";
+import { GetFungibleBalanceService } from "../../gateway/getFungibleBalance";
+import { GetEntityDetailsError } from "../../gateway/getEntityDetails";
+import type { AtLedgerState } from "../../gateway/schemas";
+import { FluxConstants } from "./constants";
+
+export class FluxReservoirNotFoundError {
+  readonly _tag = "FluxReservoirNotFoundError";
+  constructor(readonly error: unknown) {}
+}
+
+export class InvalidCollateralAddressError {
+  readonly _tag = "InvalidCollateralAddressError";
+  constructor(readonly error: unknown) {}
+}
+
+export type FluxReservoirPosition = {
+  collateralAddress: string;
+  userPoolTokenBalance: BigNumber;
+  userPoolTokenValue: {
+    collateral: BigNumber;
+    fusd: BigNumber;
+  };
+  totalPoolTokens: BigNumber;
+  poolTokenValue: {
+    collateral: BigNumber;
+    fusd: BigNumber;
+  };
+};
+
+export type GetFluxReservoirServiceInput = {
+  accountAddresses: string[];
+  stateVersion?: AtLedgerState;
+};
+
+export type GetFluxReservoirServiceOutput = {
+  items: {
+    accountAddress: string;
+    reservoirPositions: FluxReservoirPosition[];
+  }[];
+};
+
+export class GetFluxReservoirService extends Context.Tag(
+  "GetFluxReservoirService"
+)<
+  GetFluxReservoirService,
+  (input: {
+    accountAddresses: string[];
+    at_ledger_state: AtLedgerState;
+  }) => Effect.Effect<
+    GetFluxReservoirServiceOutput,
+    | FluxReservoirNotFoundError
+    | GetEntityDetailsError
+    | EntityNotFoundError
+    | InvalidInputError
+    | GatewayError
+    | InvalidCollateralAddressError,
+    | GetLedgerStateService
+    | GatewayApiClientService
+    | EntityFungiblesPageService
+    | GetFungibleBalanceService
+  >
+>() {}
+
+export const GetFluxReservoirLive = Layer.effect(
+  GetFluxReservoirService,
+  Effect.gen(function* () {
+    const getFungibleBalanceService = yield* GetFungibleBalanceService;
+    const gatewayClient = yield* GatewayApiClientService;
+
+    return (input) => {
+      return Effect.gen(function* () {
+        const collateralsToCheck = [
+          FluxConstants.collaterals.xrd,
+          FluxConstants.collaterals.lsulp,
+        ];
+
+        // Get all user balances in one call
+        const userBalancesResult = yield* getFungibleBalanceService({
+          addresses: input.accountAddresses,
+          at_ledger_state: input.at_ledger_state,
+        });
+
+        // Pre-fetch pool data for each collateral
+        const poolData = yield* Effect.forEach(
+          collateralsToCheck,
+          (collateral) =>
+            Effect.gen(function* () {
+              const poolTokenResponse = yield* Effect.tryPromise({
+                try: () =>
+                  gatewayClient.gatewayApiClient.state.innerClient.stateEntityDetails(
+                    {
+                      stateEntityDetailsRequest: {
+                        addresses: [collateral.stabilityPoolTokenAddress],
+                        at_ledger_state: input.at_ledger_state,
+                        aggregation_level: "Global",
+                      },
+                    }
+                  ),
+                catch: (error) => new GetEntityDetailsError(error),
+              });
+
+              const poolTokenEntity = poolTokenResponse.items[0];
+              if (
+                !poolTokenEntity?.details ||
+                poolTokenEntity.details.type !== "FungibleResource"
+              ) {
+                return null;
+              }
+
+              const totalPoolTokens = new BigNumber(
+                poolTokenEntity.details.total_supply
+              );
+
+              const poolResponse = yield* Effect.tryPromise({
+                try: () =>
+                  gatewayClient.gatewayApiClient.state.innerClient.stateEntityDetails(
+                    {
+                      stateEntityDetailsRequest: {
+                        addresses: [collateral.stabilityPoolAddress],
+                        at_ledger_state: input.at_ledger_state,
+                        aggregation_level: "Global",
+                      },
+                    }
+                  ),
+                catch: (error) => new GetEntityDetailsError(error),
+              });
+
+              const poolEntity = poolResponse.items[0];
+              if (!poolEntity?.fungible_resources?.items) {
+                return null;
+              }
+
+              let fusdInPool = new BigNumber(0);
+              let collateralInPool = new BigNumber(0);
+
+              for (const resource of poolEntity.fungible_resources.items) {
+                if (resource.aggregation_level === "Global") {
+                  if (
+                    resource.resource_address ===
+                    FluxConstants.fusdResourceAddress
+                  ) {
+                    fusdInPool = new BigNumber(resource.amount);
+                  } else if (
+                    resource.resource_address === collateral.collateralAddress
+                  ) {
+                    collateralInPool = new BigNumber(resource.amount);
+                  }
+                }
+              }
+
+              const fusdPerPoolUnit = totalPoolTokens.gt(0)
+                ? fusdInPool.dividedBy(totalPoolTokens)
+                : new BigNumber(0);
+              const collateralPerPoolUnit = totalPoolTokens.gt(0)
+                ? collateralInPool.dividedBy(totalPoolTokens)
+                : new BigNumber(0);
+
+              return {
+                collateral,
+                totalPoolTokens,
+                poolTokenValue: {
+                  collateral: collateralPerPoolUnit,
+                  fusd: fusdPerPoolUnit,
+                },
+              };
+            })
+        );
+
+        const items: GetFluxReservoirServiceOutput["items"] = [];
+
+        for (const accountAddress of input.accountAddresses) {
+          const reservoirPositions: FluxReservoirPosition[] = [];
+          const userAccount = userBalancesResult.find(
+            (account) => account.address === accountAddress
+          );
+
+          for (const poolDataItem of poolData) {
+            if (!poolDataItem) continue;
+
+            const { collateral, totalPoolTokens, poolTokenValue } =
+              poolDataItem;
+
+            const userPoolTokenBalance =
+              userAccount?.fungibleResources.find(
+                (resource) =>
+                  resource.resourceAddress ===
+                  collateral.stabilityPoolTokenAddress
+              )?.amount || new BigNumber(0);
+
+            const userPoolTokenValue = {
+              collateral: userPoolTokenBalance.multipliedBy(
+                poolTokenValue.collateral
+              ),
+              fusd: userPoolTokenBalance.multipliedBy(poolTokenValue.fusd),
+            };
+
+            reservoirPositions.push({
+              collateralAddress: collateral.collateralAddress,
+              userPoolTokenBalance,
+              userPoolTokenValue,
+              totalPoolTokens,
+              poolTokenValue,
+            });
+          }
+
+          items.push({
+            accountAddress,
+            reservoirPositions,
+          });
+        }
+
+        return {
+          items,
+        };
+      });
+    };
+  })
+);

--- a/packages/effects/src/dapps/flux/index.ts
+++ b/packages/effects/src/dapps/flux/index.ts
@@ -1,0 +1,4 @@
+export * from "./constants";
+export * from "./schemas";
+export * from "./getFluxCdps";
+export * from "./getFluxReservoir";

--- a/packages/effects/src/dapps/flux/schemas.ts
+++ b/packages/effects/src/dapps/flux/schemas.ts
@@ -1,0 +1,23 @@
+import s from "sbor-ez-mode";
+
+export const CdpStatus = s.enum([
+  { variant: "Healthy", schema: s.tuple([]) },
+  { variant: "Liquidated", schema: s.tuple([]) },
+  { variant: "Redeemed", schema: s.tuple([]) },
+  { variant: "Closed", schema: s.tuple([]) },
+  { variant: "Marked", schema: s.tuple([]) },
+]);
+
+export const CdpNftData = s.struct({
+  key_image_url: s.string(),
+  collateral_address: s.address(),
+  collateral_amount: s.decimal(),
+  pool_debt: s.decimal(),
+  collateral_fusd_ratio: s.decimal(),
+  interest: s.decimal(),
+  last_interest_change: s.instant(),
+  status: CdpStatus,
+  privileged_borrower: s.option(s.nonFungibleLocalId()),
+});
+
+export type CdpNftData = s.infer<typeof CdpNftData>;

--- a/packages/effects/src/dapps/index.ts
+++ b/packages/effects/src/dapps/index.ts
@@ -1,3 +1,4 @@
 export * from "./caviarnine";
+export * from "./flux";
 export * from "./rootFinance";
 export * from "./weftFinance";


### PR DESCRIPTION
## Description
This PR adds Flux Protocol dApp integration to the library, providing functionality to query CDPs and Reservoir positions.

### Features
- **CDP Queries**: Get detailed information at specified state version about user CDPs including:
  - Collateral amounts
  - Debt amounts
  - Interest rates
  - Position status
  - Privileged borrower status

- **Reservoir Queries**: Get users' reservoir (aka stability pool) positions at specified state version including:
  - Pool token balances
  - Collateral and FUSD values of those pool tokens
  - Total pool tokens in circulation
  - Value of 1 pool token

### Technical Details
- Uses `BigNumber` for precise decimal handling
- Efficient API call batching as efficient as possible (I think ha)
- Provides type-safe schemas and constants
- Follows the library's established patterns for dapp integrations as best I could

### Testing
- Includes test coverage that demonstrate proper usage of the new functionality

### Files Added
- `getFluxCdps.ts` - CDP query implementation
- `getFluxReservoir.ts` - Reservoir query implementation
- `schemas.ts` - Type definitions and schemas
- `constants.ts` - Protocol constants and addresses
- `index.ts` - Public exports
- Test files for both main features

## Future improvements
- Abstract away pool token logic (get total pool token supply, get value of 1 pool token, etc.), seems like this would be useful for many other dApps as well.