### PR TITLE
refactor: update imports to @radix-effects/shared and export error classes

### DIFF
--- a/packages/gateway/src/getNftResourceManagers.ts
+++ b/packages/gateway/src/getNftResourceManagers.ts
@@ -22,7 +22,6 @@ export class GetNftResourceManagersService extends Effect.Service<GetNftResource
   'GetNftResourceManagersService',
   {
     dependencies: [
-      GatewayApiClient.Default,
       EntityNonFungiblesPage.Default,
       EntityNonFungibleIdsPage.Default,
     ],

--- a/packages/gateway/src/getResourceHolders.ts
+++ b/packages/gateway/src/getResourceHolders.ts
@@ -5,7 +5,6 @@ import { GatewayApiClient } from './gatewayApiClient';
 export class GetResourceHoldersService extends Effect.Service<GetResourceHoldersService>()(
   'GetResourceHoldersService',
   {
-    dependencies: [GatewayApiClient.Default],
     effect: Effect.gen(function* () {
       const gatewayClient = yield* GatewayApiClient;
 

--- a/packages/gateway/src/keyValueStoreData.ts
+++ b/packages/gateway/src/keyValueStoreData.ts
@@ -7,7 +7,7 @@ import type { AtLedgerState } from './schemas';
 export class KeyValueStoreDataService extends Effect.Service<KeyValueStoreDataService>()(
   'KeyValueStoreDataService',
   {
-    dependencies: [GatewayApiClient.Default],
+    dependencies: [],
     effect: Effect.gen(function* () {
       const gatewayClient = yield* GatewayApiClient;
       const pageSize = yield* Config.number(

--- a/packages/gateway/src/previewTransaction.ts
+++ b/packages/gateway/src/previewTransaction.ts
@@ -12,7 +12,6 @@ export class TransactionPreviewError extends Data.TaggedError(
 export class PreviewTransaction extends Effect.Service<PreviewTransaction>()(
   'PreviewTransaction',
   {
-    dependencies: [GatewayApiClient.Default],
     effect: Effect.gen(function* () {
       const gatewayApiClient = yield* GatewayApiClient;
 

--- a/packages/tx-tool/src/compileTransaction.ts
+++ b/packages/tx-tool/src/compileTransaction.ts
@@ -5,7 +5,7 @@ import {
   TransactionBuilder as RetTransactionBuilder,
 } from '@radixdlt/radix-engine-toolkit';
 import { Data, Effect, pipe, Schema } from 'effect';
-import { HexString } from 'shared/brandedTypes';
+import { HexString } from '@radix-effects/shared';
 import { NotaryKeyPair } from './notaryKeyPair';
 import {
   Ed25519SignatureWithPublicKeySchema,

--- a/packages/tx-tool/src/createTransactionIntent.spec.ts
+++ b/packages/tx-tool/src/createTransactionIntent.spec.ts
@@ -11,7 +11,7 @@ import {
   Redacted,
   TestClock,
 } from 'effect';
-import { AccountAddress, HexString } from 'shared/brandedTypes';
+import { AccountAddress, HexString } from '@radix-effects/shared';
 import { CompileTransaction } from './compileTransaction';
 import { CreateTransactionIntent } from './createTransactionIntent';
 import { IntentHashService } from './intentHash';

--- a/packages/tx-tool/src/createTransactionIntent.ts
+++ b/packages/tx-tool/src/createTransactionIntent.ts
@@ -5,7 +5,7 @@ import {
   NetworkId,
   TransactionManifestString,
   TransactionMessageString,
-} from 'shared/brandedTypes';
+} from '@radix-effects/shared';
 import {
   ManifestSchema,
   TransactionIntentSchema,

--- a/packages/tx-tool/src/epoch.ts
+++ b/packages/tx-tool/src/epoch.ts
@@ -1,6 +1,6 @@
 import { GetLedgerStateService } from '@radix-effects/gateway';
 import { Data, Effect } from 'effect';
-import { Epoch, type TransactionId } from 'shared/brandedTypes';
+import { Epoch, type TransactionId } from '@radix-effects/shared';
 import type { TransactionIntent } from './schemas';
 
 export class InvalidEndEpochError extends Data.TaggedError(

--- a/packages/tx-tool/src/index.ts
+++ b/packages/tx-tool/src/index.ts
@@ -1,0 +1,16 @@
+export * from './manifests';
+export * from './signer';
+export * from './test-helpers';
+export * from './compileTransaction';
+export * from './createTransactionIntent';
+export * from './epoch';
+export * from './intentHash';
+export * from './notaryKeyPair';
+export * from './previewTransaction';
+export * from './staticallyValidateManifest';
+export * from './submitTransaction';
+export * from './transactionHeader';
+export * from './transactionHelper';
+export * from './transactionStatus';
+import * as schemas from './schemas';
+export { schemas };

--- a/packages/tx-tool/src/intentHash.ts
+++ b/packages/tx-tool/src/intentHash.ts
@@ -1,9 +1,9 @@
 import { Convert, RadixEngineToolkit } from '@radixdlt/radix-engine-toolkit';
 import { Data, Effect, pipe } from 'effect';
-import { HexString, TransactionId } from 'shared/brandedTypes';
+import { HexString, TransactionId } from '@radix-effects/shared';
 import type { TransactionIntent } from './schemas';
 
-class FailedToCreateIntentHashError extends Data.TaggedError(
+export class FailedToCreateIntentHashError extends Data.TaggedError(
   'FailedToCreateIntentHashError',
 )<{
   error: unknown;

--- a/packages/tx-tool/src/manifests/addFeePayer.ts
+++ b/packages/tx-tool/src/manifests/addFeePayer.ts
@@ -1,6 +1,6 @@
-import type { Amount } from 'shared/brandedTypes';
-import { TransactionManifestString } from 'shared/brandedTypes';
-import type { Account } from 'shared/schemas/account';
+import type { Amount } from '@radix-effects/shared';
+import { TransactionManifestString } from '@radix-effects/shared';
+import type { Account } from '@radix-effects/shared';
 
 export const addFeePayer = (input: { account: Account; amount: Amount }) => {
   if (input.account.type === 'unsecurifiedAccount') {

--- a/packages/tx-tool/src/manifests/createBadge.ts
+++ b/packages/tx-tool/src/manifests/createBadge.ts
@@ -1,5 +1,5 @@
-import { TransactionManifestString } from 'shared/brandedTypes';
-import type { Account } from 'shared/schemas/account';
+import { TransactionManifestString } from '@radix-effects/shared';
+import type { Account } from '@radix-effects/shared';
 
 export const createBadge = (account: Account, initialSupply = 1) =>
   TransactionManifestString.make(`      

--- a/packages/tx-tool/src/manifests/createFungibleToken.ts
+++ b/packages/tx-tool/src/manifests/createFungibleToken.ts
@@ -1,5 +1,5 @@
-import { type Amount, TransactionManifestString } from 'shared/brandedTypes';
-import type { Account } from 'shared/schemas/account';
+import { type Amount, TransactionManifestString } from '@radix-effects/shared';
+import type { Account } from '@radix-effects/shared';
 
 export const createFungibleTokenManifest = (input: {
   name: string;

--- a/packages/tx-tool/src/manifests/faucet.ts
+++ b/packages/tx-tool/src/manifests/faucet.ts
@@ -1,7 +1,7 @@
 import { RadixEngineToolkit } from '@radixdlt/radix-engine-toolkit';
 import { Effect } from 'effect';
-import type { AccountAddress } from 'shared/brandedTypes';
-import { TransactionManifestString } from 'shared/brandedTypes';
+import type { AccountAddress } from '@radix-effects/shared';
+import { TransactionManifestString } from '@radix-effects/shared';
 
 export const faucet = (accountAddress: AccountAddress) =>
   Effect.gen(function* () {

--- a/packages/tx-tool/src/manifests/index.ts
+++ b/packages/tx-tool/src/manifests/index.ts
@@ -1,0 +1,5 @@
+export * from './addFeePayer';
+export * from './createBadge';
+export * from './createFungibleToken';
+export * from './faucet';
+export * from './manifestHelper';

--- a/packages/tx-tool/src/manifests/manifestHelper.ts
+++ b/packages/tx-tool/src/manifests/manifestHelper.ts
@@ -1,7 +1,7 @@
 import { Effect } from 'effect';
-import type { Amount } from 'shared/brandedTypes';
-import { TransactionManifestString } from 'shared/brandedTypes';
-import type { Account } from 'shared/schemas/account';
+import type { Amount } from '@radix-effects/shared';
+import { TransactionManifestString } from '@radix-effects/shared';
+import type { Account } from '@radix-effects/shared';
 
 export class ManifestHelper extends Effect.Service<ManifestHelper>()(
   'ManifestHelper',

--- a/packages/tx-tool/src/notaryKeyPair.ts
+++ b/packages/tx-tool/src/notaryKeyPair.ts
@@ -1,6 +1,6 @@
 import { Signature } from '@radixdlt/radix-engine-toolkit';
 import { Array as A, Effect, flow, Option } from 'effect';
-import type { HexString } from 'shared/brandedTypes';
+import type { HexString } from '@radix-effects/shared';
 import { Signer } from './signer/signer';
 
 export class NotaryKeyPair extends Effect.Service<NotaryKeyPair>()(

--- a/packages/tx-tool/src/schemas.ts
+++ b/packages/tx-tool/src/schemas.ts
@@ -14,7 +14,7 @@ import {
   Nonce,
   TransactionManifestString,
   TransactionMessageString,
-} from 'shared/brandedTypes';
+} from '@radix-effects/shared';
 
 export const Base64FromHexSchema = Schema.asSchema(
   Schema.transformOrFail(HexString, Base64String, {

--- a/packages/tx-tool/src/signer/index.ts
+++ b/packages/tx-tool/src/signer/index.ts
@@ -1,0 +1,2 @@
+export * from './signer';
+export * from './vault';

--- a/packages/tx-tool/src/signer/signer.ts
+++ b/packages/tx-tool/src/signer/signer.ts
@@ -1,6 +1,6 @@
 import { Convert, PublicKey } from '@radixdlt/radix-engine-toolkit';
 import { Context, Data, Effect, Layer, Redacted, Schema } from 'effect';
-import type { HexString } from 'shared/brandedTypes';
+import type { HexString } from '@radix-effects/shared';
 import {
   Ed25519PrivateKeySchema,
   type Ed25519SignatureWithPublicKey,

--- a/packages/tx-tool/src/signer/vault.spec.ts
+++ b/packages/tx-tool/src/signer/vault.spec.ts
@@ -2,7 +2,7 @@ import { HttpClient, HttpClientResponse } from '@effect/platform';
 import { NodeFileSystem } from '@effect/platform-node';
 import { layer } from '@effect/vitest';
 import { Effect, Exit, Layer, Logger } from 'effect';
-import { HexString } from 'shared/brandedTypes';
+import { HexString } from '@radix-effects/shared';
 import { describe, expect, it } from 'vitest';
 import { Vault } from './vault';
 

--- a/packages/tx-tool/src/signer/vault.ts
+++ b/packages/tx-tool/src/signer/vault.ts
@@ -14,7 +14,7 @@ import {
   Schedule,
   Schema,
 } from 'effect';
-import { Base64String, HexString } from 'shared/brandedTypes';
+import { Base64String, HexString } from '@radix-effects/shared';
 import {
   Base64FromHexSchema,
   Ed25519SignatureWithPublicKeySchema,

--- a/packages/tx-tool/src/staticallyValidateManifest.ts
+++ b/packages/tx-tool/src/staticallyValidateManifest.ts
@@ -1,16 +1,18 @@
 import { RadixEngineToolkit } from '@radixdlt/radix-engine-toolkit';
 
 import { Data, Effect } from 'effect';
-import type { NetworkId } from 'shared/brandedTypes';
+import type { NetworkId } from '@radix-effects/shared';
 import type { Manifest } from './schemas';
 
-class FailedToStaticallyValidateManifestError extends Data.TaggedError(
+export class FailedToStaticallyValidateManifestError extends Data.TaggedError(
   'FailedToStaticallyValidateManifestError',
 )<{
   error: unknown;
 }> {}
 
-class InvalidManifestError extends Data.TaggedError('InvalidManifestError')<{
+export class InvalidManifestError extends Data.TaggedError(
+  'InvalidManifestError',
+)<{
   message: string;
 }> {}
 

--- a/packages/tx-tool/src/test-helpers/index.ts
+++ b/packages/tx-tool/src/test-helpers/index.ts
@@ -1,0 +1,2 @@
+export * from './createAccount';
+export * from './disableTestClock';

--- a/packages/tx-tool/src/transactionHeader.ts
+++ b/packages/tx-tool/src/transactionHeader.ts
@@ -1,7 +1,7 @@
 import { GetLedgerStateService } from '@radix-effects/gateway';
 import { generateRandomNonce } from '@radixdlt/radix-engine-toolkit';
 import { Data, Effect, Option, pipe } from 'effect';
-import { Epoch, type NetworkId, Nonce } from 'shared/brandedTypes';
+import { Epoch, type NetworkId, Nonce } from '@radix-effects/shared';
 import { EpochService } from './epoch';
 import { NotaryKeyPair } from './notaryKeyPair';
 import { TransactionHeaderSchema } from './schemas';

--- a/packages/tx-tool/src/transactionHelper.spec.ts
+++ b/packages/tx-tool/src/transactionHelper.spec.ts
@@ -9,7 +9,7 @@ import {
   Logger,
   Redacted,
 } from 'effect';
-import { HexString } from 'shared/brandedTypes';
+import { HexString } from '@radix-effects/shared';
 import { Signer } from './signer/signer';
 import { createAccount } from './test-helpers/createAccount';
 import {

--- a/packages/tx-tool/src/transactionHelper.ts
+++ b/packages/tx-tool/src/transactionHelper.ts
@@ -21,8 +21,8 @@ import {
   NetworkId,
   type TransactionId,
   TransactionManifestString,
-} from 'shared/brandedTypes';
-import type { Account } from 'shared/schemas/account';
+  type Account,
+} from '@radix-effects/shared';
 
 import { CompileTransaction } from './compileTransaction';
 import { CreateTransactionIntent } from './createTransactionIntent';

--- a/packages/tx-tool/src/transactionStatus.ts
+++ b/packages/tx-tool/src/transactionStatus.ts
@@ -1,9 +1,9 @@
 import { GatewayApiClient } from '@radix-effects/gateway';
 import type { TransactionStatusResponse } from '@radixdlt/babylon-gateway-api-sdk';
 import { Config, Data, Duration, Effect, Schedule } from 'effect';
-import type { TransactionId } from 'shared/brandedTypes';
+import type { TransactionId } from '@radix-effects/shared';
 
-class TransactionNotResolvedError extends Data.TaggedError(
+export class TransactionNotResolvedError extends Data.TaggedError(
   'TransactionNotResolvedError',
 )<{
   status: TransactionStatusResponse['intent_status'];
@@ -12,7 +12,7 @@ class TransactionNotResolvedError extends Data.TaggedError(
   transactionId: TransactionId;
 }> {}
 
-class TransactionFailedError extends Data.TaggedError(
+export class TransactionFailedError extends Data.TaggedError(
   'TransactionFailedError',
 )<{
   status: TransactionStatusResponse['intent_status'];
@@ -21,7 +21,7 @@ class TransactionFailedError extends Data.TaggedError(
   transactionId: TransactionId;
 }> {}
 
-class TimeoutError extends Data.TaggedError('TimeoutError')<{
+export class TimeoutError extends Data.TaggedError('TimeoutError')<{
   transactionId: TransactionId;
 }> {}
 


### PR DESCRIPTION
## Summary
- Replace `shared/brandedTypes` imports with `@radix-effects/shared` across tx-tool package
- Remove redundant `GatewayApiClient.Default` from service dependencies (gateway package)
- Export error classes for better error handling by consumers
- Add barrel export files (index.ts) for tx-tool modules

## Test plan
- [ ] Verify build passes with new import paths
- [ ] Ensure all tests pass
- [ ] Check that exported error classes are accessible from package entry point

🤖 Generated with [Claude Code](https://claude.com/claude-code)