### PR TITLE
feat: make `at_ledger_state` optional in gateway services

### DIFF
--- a/packages/gateway/src/getAddressByNonFungible.ts
+++ b/packages/gateway/src/getAddressByNonFungible.ts
@@ -9,7 +9,7 @@ class EntityNotFoundError extends Data.TaggedError('EntityNotFoundError')<{
 export type GetAddressByNonFungibleServiceInput = {
   resourceAddress: string;
   nonFungibleId: string;
-  at_ledger_state: AtLedgerState;
+  at_ledger_state?: AtLedgerState;
 };
 
 export class GetAddressByNonFungibleService extends Effect.Service<GetAddressByNonFungibleService>()(

--- a/packages/gateway/src/getComponentState.ts
+++ b/packages/gateway/src/getComponentState.ts
@@ -28,7 +28,7 @@ export class GetComponentStateService extends Effect.Service<GetComponentStateSe
           R extends boolean,
         >(input: {
           addresses: string[];
-          at_ledger_state: AtLedgerState;
+          at_ledger_state?: AtLedgerState;
           schema: StructSchema<T, R>;
           options?: GetEntityDetailsOptions;
         }) {

--- a/packages/gateway/src/getKeyValueStore.ts
+++ b/packages/gateway/src/getKeyValueStore.ts
@@ -16,12 +16,16 @@ export class GetKeyValueStoreService extends Effect.Service<GetKeyValueStoreServ
 
       return Effect.fn(function* (input: {
         address: string;
-        at_ledger_state: AtLedgerState;
+        at_ledger_state?: AtLedgerState;
       }) {
         const keyResults = yield* keyValueStoreKeysService({
           key_value_store_address: input.address,
           at_ledger_state: input.at_ledger_state,
         });
+
+        const paginationState = {
+          state_version: keyResults.ledger_state.state_version,
+        };
 
         const allKeys = [...keyResults.items];
 
@@ -30,7 +34,7 @@ export class GetKeyValueStoreService extends Effect.Service<GetKeyValueStoreServ
         while (nextCursor) {
           const nextKeyResults = yield* keyValueStoreKeysService({
             key_value_store_address: input.address,
-            at_ledger_state: input.at_ledger_state,
+            at_ledger_state: paginationState,
             cursor: nextCursor,
           });
 
@@ -44,7 +48,7 @@ export class GetKeyValueStoreService extends Effect.Service<GetKeyValueStoreServ
           keys: allKeys.map(({ key }) => ({
             key_json: key.programmatic_json,
           })),
-          at_ledger_state: input.at_ledger_state,
+          at_ledger_state: paginationState,
         }).pipe(
           Effect.map((res) => {
             const { key_value_store_address, ledger_state } = res[0]!;

--- a/packages/gateway/src/getLedgerState.ts
+++ b/packages/gateway/src/getLedgerState.ts
@@ -4,7 +4,7 @@ import { GatewayApiClient } from './gatewayApiClient';
 import type { AtLedgerState } from './schemas';
 
 export type GetLedgerStateInput = {
-  at_ledger_state: AtLedgerState;
+  at_ledger_state?: AtLedgerState;
 };
 
 export class GetLedgerStateService extends Effect.Service<GetLedgerStateService>()(

--- a/packages/gateway/src/getNonFungibleBalance.ts
+++ b/packages/gateway/src/getNonFungibleBalance.ts
@@ -12,7 +12,7 @@ export class InvalidInputError {
 
 type GetNonFungibleBalanceInput = {
   addresses: string[];
-  at_ledger_state: AtLedgerState;
+  at_ledger_state?: AtLedgerState;
   resourceAddresses?: string[];
   options?: StateEntityDetailsOperationRequest['stateEntityDetailsRequest']['opt_ins'];
 };
@@ -43,7 +43,7 @@ export class GetNonFungibleBalanceService extends Effect.Service<GetNonFungibleB
           nftIds: string[];
         }[];
 
-        at_ledger_state: AtLedgerState;
+        at_ledger_state?: AtLedgerState;
       }) {
         return yield* Effect.forEach(
           input.items,

--- a/packages/gateway/src/getNonFungibleLocation.ts
+++ b/packages/gateway/src/getNonFungibleLocation.ts
@@ -14,7 +14,7 @@ export class GetNonFungibleLocationService extends Effect.Service<GetNonFungible
       return Effect.fn(function* (input: {
         resourceAddress: string;
         nonFungibleIds: string[];
-        at_ledger_state: AtLedgerState;
+        at_ledger_state?: AtLedgerState;
       }) {
         const chunks = chunker(input.nonFungibleIds, pageSize);
         return yield* Effect.forEach(

--- a/packages/gateway/src/keyValueStoreData.ts
+++ b/packages/gateway/src/keyValueStoreData.ts
@@ -16,7 +16,7 @@ export class KeyValueStoreDataService extends Effect.Service<KeyValueStoreDataSe
 
       return Effect.fn(function* (
         input: Omit<StateKeyValueStoreDataRequest, 'at_ledger_state'> & {
-          at_ledger_state: AtLedgerState;
+          at_ledger_state?: AtLedgerState;
         },
       ) {
         const chunks = chunker(input.keys, pageSize);

--- a/packages/gateway/src/keyValueStoreKeys.ts
+++ b/packages/gateway/src/keyValueStoreKeys.ts
@@ -15,7 +15,7 @@ export class KeyValueStoreKeysService extends Effect.Service<KeyValueStoreKeysSe
 
       return Effect.fn(function* (
         input: Omit<StateKeyValueStoreKeysRequest, 'at_ledger_state'> & {
-          at_ledger_state: AtLedgerState;
+          at_ledger_state?: AtLedgerState;
         },
       ) {
         return yield* gatewayClient.state.innerClient.keyValueStoreKeys({

--- a/packages/gateway/src/state/entityFungiblesPage.ts
+++ b/packages/gateway/src/state/entityFungiblesPage.ts
@@ -8,7 +8,7 @@ type EntityFungiblesPageInput = Omit<
   EntityFungiblesPageRequest['stateEntityFungiblesPageRequest'],
   'at_ledger_state'
 > & {
-  at_ledger_state: AtLedgerState;
+  at_ledger_state?: AtLedgerState;
 };
 
 export class EntityFungiblesPage extends Effect.Service<EntityFungiblesPage>()(
@@ -37,6 +37,9 @@ export class EntityFungiblesPage extends Effect.Service<EntityFungiblesPage>()(
         input: EntityFungiblesPageInput,
       ) {
         const result = yield* entityFungiblesPage(input);
+        const paginationState = {
+          state_version: result.ledger_state.state_version,
+        };
         let nextCursor = result?.next_cursor;
 
         const items = result?.items ?? [];
@@ -44,6 +47,7 @@ export class EntityFungiblesPage extends Effect.Service<EntityFungiblesPage>()(
         while (nextCursor) {
           const result = yield* entityFungiblesPage({
             ...input,
+            at_ledger_state: paginationState,
             cursor: nextCursor,
           });
           nextCursor = result.next_cursor;

--- a/packages/gateway/src/state/entityNonFungiblesPage.ts
+++ b/packages/gateway/src/state/entityNonFungiblesPage.ts
@@ -17,7 +17,7 @@ export class EntityNonFungiblesPage extends Effect.Service<EntityNonFungiblesPag
           EntityNonFungiblesPageRequest['stateEntityNonFungiblesPageRequest'],
           'at_ledger_state'
         > & {
-          at_ledger_state: AtLedgerState;
+          at_ledger_state?: AtLedgerState;
         },
       ) {
         const result =

--- a/packages/gateway/src/state/getEntityDetailsVaultAggregated.ts
+++ b/packages/gateway/src/state/getEntityDetailsVaultAggregated.ts
@@ -26,7 +26,7 @@ export class GetEntityDetailsVaultAggregated extends Effect.Service<GetEntityDet
       return Effect.fnUntraced(function* (
         input: GetEntityDetailsInput,
         options: GetEntityDetailsOptions,
-        at_ledger_state: AtLedgerState,
+        at_ledger_state?: AtLedgerState,
       ) {
         const chunks = chunker(input, pageSize);
         return yield* Effect.forEach(

--- a/packages/gateway/src/state/nonFungibleData.ts
+++ b/packages/gateway/src/state/nonFungibleData.ts
@@ -18,7 +18,7 @@ export class NonFungibleData extends Effect.Service<NonFungibleData>()(
           NonFungibleDataRequest['stateNonFungibleDataRequest'],
           'at_ledger_state'
         > & {
-          at_ledger_state: AtLedgerState;
+          at_ledger_state?: AtLedgerState;
         },
       ) {
         const chunks = chunker(input.non_fungible_ids, pageSize);


### PR DESCRIPTION
- made `at_ledger_state` optional across all gateway service inputs
- added pagination state pinning (extracting `state_version` from first response) in services that paginate:
  `entityFungiblesPage`, `entityNonFungibleIdsPage`, `getFungibleBalance`, `getKeyValueStore`, `getNftResourceManagers`

**no breaking changes**: callers that already pass at_ledger_state continue to work as before