### PR TITLE
Add x402 Radix reference implementation

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["docs"]
+  "ignore": ["docs", "@radix-effects/x402-example"]
 }

--- a/.changeset/x402-subintent-release.md
+++ b/.changeset/x402-subintent-release.md
@@ -1,0 +1,10 @@
+---
+"@radix-effects/tx-tool": minor
+"rdx-cli": minor
+---
+
+Add standalone Subintent signing support for Radix x402 payment flows.
+
+`rdx-cli` now exposes `rdx subintent prepare` and `rdx subintent build` for creating a root Subintent signing request and building a signed partial transaction from an out-of-band signature.
+
+`@radix-effects/tx-tool` now exposes signed partial transaction inspection helpers so servers can validate signed Subintent payloads before settling them.

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -12,6 +12,7 @@ permissions:
 
 env:
   CI: true
+  NPM_TOKEN: unused
 
 jobs:
   changeset:

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -1,0 +1,35 @@
+name: Changeset Check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+env:
+  CI: true
+
+jobs:
+  changeset:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: install dependencies
+        run: pnpm install
+
+      - name: check release intent
+        run: pnpm changeset status --since=origin/main

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -13,6 +13,8 @@ permissions:
 env:
   CI: true
   NPM_TOKEN: unused
+  FORCE_COLOR: "0"
+  NO_COLOR: "1"
 
 jobs:
   changeset:

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -48,6 +48,7 @@ jobs:
 
       - name: comment release intent
         uses: actions/github-script@v7
+        continue-on-error: true
         env:
           CHANGESET_STATUS: ${{ steps.changeset.outputs.status }}
           CHANGESET_OUTPUT: ${{ steps.changeset.outputs.output }}

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -81,30 +81,36 @@ jobs:
 
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner,
-              repo,
-              issue_number,
-              per_page: 100,
-            });
-            const existing = comments.find((comment) =>
-              comment.body?.includes(marker)
-            );
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner,
-                repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
+            try {
+              const comments = await github.paginate(github.rest.issues.listComments, {
                 owner,
                 repo,
                 issue_number,
-                body,
+                per_page: 100,
               });
+              const existing = comments.find((comment) =>
+                comment.body?.includes(marker)
+              );
+
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: existing.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number,
+                  body,
+                });
+              }
+            } catch (error) {
+              core.warning(
+                `Unable to write Changeset PR comment: ${error.message}`
+              );
             }
 
       - name: fail on invalid release intent

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
   issues: write
 
 env:

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  issues: write
 
 env:
   CI: true
@@ -32,4 +33,79 @@ jobs:
         run: pnpm install
 
       - name: check release intent
-        run: pnpm changeset status --since=origin/main
+        id: changeset
+        shell: bash
+        run: |
+          set +e
+          output="$(pnpm changeset status --since=origin/main 2>&1)"
+          status="$?"
+          {
+            echo "status=$status"
+            echo "output<<CHANGESET_STATUS"
+            echo "$output"
+            echo "CHANGESET_STATUS"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: comment release intent
+        uses: actions/github-script@v7
+        env:
+          CHANGESET_STATUS: ${{ steps.changeset.outputs.status }}
+          CHANGESET_OUTPUT: ${{ steps.changeset.outputs.output }}
+        with:
+          script: |
+            const marker = "<!-- changeset-check -->";
+            const status = process.env.CHANGESET_STATUS;
+            const rawOutput = process.env.CHANGESET_OUTPUT ?? "";
+            const output = rawOutput.length > 6000
+              ? `${rawOutput.slice(0, 6000)}\n... truncated ...`
+              : rawOutput;
+            const passed = status === "0";
+            const body = [
+              marker,
+              `## ${passed ? "Changeset check passed" : "Changeset check failed"}`,
+              "",
+              passed
+                ? "This PR has valid Changesets release intent for changed publishable packages."
+                : "This PR changes publishable packages without valid Changesets release intent. Add a `.changeset/*.md` file, or add an empty changeset if no release is needed.",
+              "",
+              "<details>",
+              "<summary>changeset status output</summary>",
+              "",
+              "```text",
+              output,
+              "```",
+              "",
+              "</details>",
+            ].join("\n");
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) =>
+              comment.body?.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
+
+      - name: fail on invalid release intent
+        if: steps.changeset.outputs.status != '0'
+        run: exit 1

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -60,9 +60,14 @@ jobs:
             const marker = "<!-- changeset-check -->";
             const status = process.env.CHANGESET_STATUS;
             const rawOutput = process.env.CHANGESET_OUTPUT ?? "";
-            const output = rawOutput.length > 6000
-              ? `${rawOutput.slice(0, 6000)}\n... truncated ...`
-              : rawOutput;
+            const plainOutput = rawOutput.replace(
+              // biome-ignore lint/suspicious/noControlCharactersInRegex: strips ANSI escape codes from command output before posting a PR comment.
+              /[\u001b\u009b][[\]()#;?]*(?:(?:(?:[a-zA-Z\d]*(?:;[a-zA-Z\d]*)*)?\u0007)|(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))/g,
+              "",
+            );
+            const output = plainOutput.length > 6000
+              ? `${plainOutput.slice(0, 6000)}\n... truncated ...`
+              : plainOutput;
             const passed = status === "0";
             const body = [
               marker,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@ on:
   push:
     branches:
       - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
 env:
   CI: true
 jobs:

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -7,6 +7,7 @@ This repo uses multiple domain contexts. Read the relevant `CONTEXT.md` before p
 | Area | Context file | Use when |
 | ---- | ------------ | -------- |
 | CLI / Agent-first CLI Wallet | `packages/cli/CONTEXT.md` | Working on `rdx`, transaction workflow artifacts, out-of-band signing, CLI file schemas, structured command output, or agent-first Radix transaction flows. |
+| x402 Radix Reference Design | `examples/x402/CONTEXT.md` | Working on the x402 reference implementation, sponsored payment flow, Hono resource server or facilitator, and agent client payment examples. |
 
 ## ADRs
 

--- a/docs/prd/x402-radix-reference-implementation.md
+++ b/docs/prd/x402-radix-reference-implementation.md
@@ -1,0 +1,142 @@
+# PRD: x402 Radix Reference Implementation
+
+## Problem Statement
+
+Developers need a runnable reference design for x402 payments on Radix that demonstrates the exact sponsored-payment settlement flow end to end. The current repo has the transaction tooling primitives, but it does not yet provide a cohesive example where a payer signs a Subintent with generic `rdx subintent` commands and a server-side facilitator validates, sponsors, submits, and waits for settlement before serving protected content.
+
+The reference must clarify the boundary between agent-owned payment signing and server-owned settlement. It must avoid teaching agents to sign arbitrary server-authored RTM, avoid exposing public facilitator endpoints, and avoid accepting optimistic payment states such as submission without committed success.
+
+## Solution
+
+Build a single runnable x402 example package that contains a Hono server, reusable x402 Payment Middleware, local markdown content, and shared payment helpers. The protected route serves a local markdown file only after the middleware has either observed a matching settled payment in memory or accepted a signed partial transaction, validated the payment Subintent, wrapped it in a sponsored root transaction, previewed it, submitted it, and observed Gateway `CommittedSuccess`.
+
+Extend the generic `rdx` CLI with Subintent commands so a payer can prepare and build a signed partial transaction without any x402-specific client agent. Extend tx-tool with a Signed Partial Transaction Inspection helper so the facilitator can derive payer details and Subintent identity from the signed payload instead of trusting HTTP metadata.
+
+The example targets Mainnet through an explicit config template with placeholders. Runtime code must reject placeholders before issuing payment requirements or settling payments.
+
+## User Stories
+
+1. As a developer, I want a runnable x402 Reference Implementation, so that I can see the full Radix payment flow rather than infer it from protocol notes.
+2. As a developer, I want the reference to live in one x402 Example Package, so that I can run the agent and server without coordinating multiple workspace packages.
+3. As a server integrator, I want a reusable x402 Payment Middleware, so that route handlers can remain focused on serving protected resources.
+4. As a server integrator, I want the middleware demonstrated on a Protected Markdown Resource, so that the example has a concrete protected HTTP resource.
+5. As a server integrator, I want the server to expose only the Protected Route Surface, so that verify and settle operations are not copied as public APIs.
+6. As a server integrator, I want the protected route to use Fixed Route Payment Terms, so that the v1 example stays deterministic and easy to audit.
+7. As a server integrator, I want the payment requirements to bind to an Absolute Resource URL, so that payment identity is not ambiguous across hosts or paths.
+8. As a server integrator, I want Placeholder Rejection for Mainnet config values, so that the runnable example never silently uses fake production settings.
+9. As a server integrator, I want distinct Fee Payer Account, Pay-To Account, and Facilitator Notary Key roles, so that sponsored settlement responsibilities are explicit.
+10. As a payer agent, I want to receive Structured Payment Requirements in the `402` response, so that I can construct the payment Subintent without trusting arbitrary server RTM.
+11. As a payer agent, I want optional advisory payment and preview templates, so that I can debug the expected shape while still treating structured terms as canonical.
+12. As a payer agent, I want to build the payment Subintent locally, so that payer intent is derived from transparent payment terms.
+13. As a payer, I want to use generic `rdx subintent` commands, so that x402 payment signing is not tied to an example-specific agent implementation.
+14. As a payer agent, I want `rdx subintent prepare` to compute the Subintent hash, so that I know exactly what is being signed.
+15. As a payer agent, I want `rdx subintent prepare` to accept a Subintent header file, so that header settings and optional message settings are explicit.
+16. As a payer agent, I want `rdx subintent prepare` to support a root manifest preview file, so that I can run a signer-safety preview before signing when enough context is available.
+17. As a payer agent, I want `rdx subintent prepare` to require the root manifest placeholder exactly once, so that preview binds to the actual Subintent hash.
+18. As a payer agent, I want `rdx subintent prepare` to perform static analysis, so that obvious payment-shape or authorization problems fail before signing.
+19. As a payer agent, I want `rdx subintent prepare` to perform best-effort preview when a root manifest is available, so that I can catch runtime failures before producing a payment payload.
+20. As a payer agent, I want `rdx subintent prepare` to support an explicit no-preview last resort, so that constrained environments can still produce a Subintent with visible risk.
+21. As a payer agent, I want durable prepared Subintent artifacts, so that the signing step is reproducible and inspectable.
+22. As a payer agent, I want `rdx subintent build` to combine a prepared Subintent and signature, so that I can produce the signed partial transaction sent to the server.
+23. As a payer agent, I want the x402 retry payload to contain the signed partial transaction as the Authoritative Payment Payload, so that no redundant payer metadata needs to be trusted.
+24. As a facilitator, I want to inspect signed partial transactions through tx-tool, so that payer account, asset, amount, expiry, and Subintent hash are derived from signed data.
+25. As a facilitator, I want to accept any Valid Payer, so that the reference demonstrates open x402 payment instead of an allowlist.
+26. As a facilitator, I want to validate the Exact Payment Subintent Shape, so that semantically different or malicious manifests are rejected.
+27. As a facilitator, I want to statically validate the signed payment Subintent, so that invalid payloads fail before a sponsored transaction is built.
+28. As a facilitator, I want to build the sponsored root transaction internally, so that fee payment and settlement stay server-owned.
+29. As a facilitator, I want to preview the sponsored root transaction through Gateway before submission, so that settlement failures are caught before spending fees where possible.
+30. As a facilitator, I want to submit only after validation and preview, so that the server does not sponsor arbitrary signed Subintents.
+31. As a facilitator, I want to poll until Gateway `CommittedSuccess`, so that the protected resource is served only after the ledger confirms payment.
+32. As a facilitator, I want `Submitted` to be insufficient for access, so that users cannot receive content on a merely pending payment.
+33. As a facilitator, I want in-memory Settlement Records, so that repeated requests after settlement can serve the resource without resubmitting the same payment.
+34. As a facilitator, I want Settlement Cache Key identity to combine Subintent hash, Payment Requirements Hash, and resource URL, so that cache hits are scoped to the exact paid resource and terms.
+35. As a developer, I want the Payment Requirements Hash to exclude advisory fields, so that debug templates do not change settlement identity.
+36. As a developer, I want Mainnet to be the Reference Network, so that the reference matches the intended production environment.
+37. As a developer, I want live Mainnet behavior to be explicitly configured, so that unit and integration tests can run without accidental live payment execution.
+38. As a maintainer, I want generic Subintent CLI support rather than x402-specific CLI commands, so that future Subintent use cases can reuse the same command surface.
+39. As a maintainer, I want tx-tool to own signed partial transaction inspection, so that examples do not duplicate low-level transaction decoding.
+40. As a maintainer, I want unit-first coverage for payment semantics, so that correctness does not depend on live ledger availability.
+41. As a maintainer, I want a live-network smoke path behind explicit config, so that the reference can prove real settlement when credentials are intentionally provided.
+42. As an AI coding agent, I want the PRD and domain language to distinguish advisory templates from canonical payment requirements, so that implementation does not accidentally make server RTM authoritative.
+43. As an AI coding agent, I want the PRD to name the payment release boundary, so that generated code does not serve protected content after submission alone.
+44. As an AI coding agent, I want the PRD to define the root manifest preview as signer-safety context, so that it is not treated as the server's canonical settlement transaction.
+
+## Implementation Decisions
+
+- Build one x402 Example Package containing the Hono server, protected markdown file, payment middleware, and shared x402 helpers.
+- Use Hono for the backend server and implement x402 Payment Middleware as the server integration point.
+- Protect a local markdown resource. The route handler reads the Protected Markdown File only after middleware marks the request as paid.
+- Keep the public server surface to the protected resource route. Facilitator verify and settle behavior is internal to middleware.
+- Use Fixed Route Payment Terms for the v1 reference.
+- Use Mainnet as the Reference Network. Ship a Mainnet Config Template with placeholders for network role configuration and payment terms.
+- Apply Placeholder Rejection before issuing payment requirements or attempting settlement.
+- Model sponsored payment roles separately: Fee Payer Account locks fees, Pay-To Account receives payment, and Facilitator Notary Key notarizes the sponsored root transaction.
+- Return Structured Payment Requirements in the initial `402` response. These are the canonical authority for payment construction.
+- Include Advisory Payment Manifest Template and Advisory Preview Root Manifest Template only as optional debug and preview aids.
+- Make the signed partial transaction the Authoritative Payment Payload in the x402 retry request.
+- Do not trust payer account, amount, asset, expiry, or Subintent hash from HTTP metadata. Derive them from Signed Partial Transaction Inspection.
+- Add a tx-tool helper for Signed Partial Transaction Inspection. The helper should decode the signed partial transaction, expose the Subintent manifest and header, compute the Subintent hash, expose signature and public-key details needed for validation, and derive payment-relevant account details.
+- Add generic `rdx subintent prepare` support. It accepts a Subintent manifest, a Subintent header file, and either a root manifest preview file or an explicit no-preview flag.
+- Add generic `rdx subintent build` support. It accepts a prepared Subintent artifact and signature file, then writes and reports the signed partial transaction hex.
+- Keep `rdx subintent` generic. The x402 reference does not include a separate client agent; payer-side signing happens through the generic CLI workflow.
+- Name the preview context `root-manifest`. It is temporary signer-safety context and is not part of the signed Subintent.
+- Require the root manifest preview file to contain the Subintent hash placeholder exactly once.
+- Support one standalone root Subintent in v1. Nested child Subintents are out of scope.
+- Include header settings and optional message settings in the Subintent header file.
+- Have `rdx subintent prepare` run static analysis and best-effort preview when a root manifest is supplied.
+- Permit no-preview only as an explicit last resort.
+- Have the payer generate both the payment Subintent manifest and root manifest preview from Structured Payment Requirements when possible.
+- Follow Preview Root Fallback on the agent side: build a root manifest preview from structured requirements, use advisory preview template if needed, and use no-preview only as the last case.
+- Validate the Exact Payment Subintent Shape on the server. The v1 server does not accept flexible or equivalent manifest variants.
+- Build the sponsored root transaction on the server. The payer never notarizes, submits, or settles the facilitator root transaction.
+- Preview the sponsored root transaction server-side through Gateway before submission.
+- Submit the sponsored root transaction only after signed payload inspection, exact Subintent validation, static validation, and preview pass.
+- Poll Gateway until `CommittedSuccess`. Treat `CommittedSuccess` as the Payment Release Boundary.
+- Store Settlement Records in memory for the runnable example.
+- Compute Settlement Cache Key from Subintent hash, Payment Requirements Hash, and Absolute Resource URL.
+- Compute Payment Requirements Hash from normalized payment semantics, excluding advisory templates and debug fields.
+- Accept any Valid Payer whose signed Subintent satisfies requirements, passes server validation, and settles successfully.
+- Keep key sourcing for payer signing internal to the CLI-facing payer environment and out of scope for the x402 reference design.
+
+## Testing Decisions
+
+- Prefer unit-first payment coverage. Tests should assert external behavior and payment semantics, not incidental implementation structure.
+- Test that payment Subintent manifest generation produces the exact v1 instruction sequence required by the server.
+- Test that root manifest preview generation contains the Subintent hash placeholder exactly once before prepare-time replacement.
+- Test that normalized Payment Requirements Hash ignores advisory templates and debug fields.
+- Test that Settlement Cache Key changes when the Subintent hash, Payment Requirements Hash, or Absolute Resource URL changes.
+- Test Placeholder Rejection for every required Mainnet config placeholder.
+- Test that server validation rejects signed Subintents with the wrong asset, amount, recipient, resource binding, parent check, or instruction order.
+- Test that server validation accepts a correctly signed payment Subintent from any payer account.
+- Test that middleware returns `402` requirements when no payment payload is present.
+- Test that middleware serves the Protected Markdown Resource only after settlement is recorded or `CommittedSuccess` is observed.
+- Test that `Submitted` or preview success alone does not serve the protected resource.
+- Test that duplicate settled requests hit the in-memory Settlement Record instead of resubmitting.
+- Test generic `rdx subintent prepare` behavior for successful prepare, missing root manifest placeholder, duplicate placeholder, static analysis failure, preview failure, and explicit no-preview.
+- Test generic `rdx subintent build` behavior for successful signed partial transaction output and invalid signature input.
+- Test tx-tool Signed Partial Transaction Inspection against known signed partial transaction fixtures.
+- Test generic `rdx subintent` behavior directly; do not add an x402-specific client agent test surface.
+- Keep live Mainnet settlement tests behind explicit configuration and skip them by default.
+- Use the existing tx-tool V2 transaction tests as prior art for compile, preview, submit, and poll behavior.
+- Preserve the existing Stokenet characterization coverage for root and Subintent header mismatch behavior as transaction-tooling evidence, but do not make it the x402 reference network.
+
+## Out of Scope
+
+- Nested child Subintents in the generic Subintent CLI.
+- Dynamic route pricing or request-dependent payment terms.
+- Public facilitator verify or settle endpoints.
+- A durable settlement database or protocol-level receipt store.
+- Payer allowlists.
+- Browser wallet integration.
+- Interactive key management UX for the agent signer.
+- Non-sponsored x402 transactions where the payer pays network fees.
+- Treating server-authored payment RTM as canonical signing authority.
+- Serving resources before Gateway `CommittedSuccess`.
+- Multiple protected resources with independent dynamic configuration.
+- Packaging x402 middleware as a standalone published library.
+
+## Further Notes
+
+- The design intentionally separates signer-safety preview from server settlement. The agent preview root manifest helps the payer understand what the Subintent is expected to do, but the server still builds, previews, submits, and polls the real sponsored root transaction.
+- Radix Subintent headers may differ from the root transaction header. Existing tx-tool characterization coverage shows that such mismatches can compile and submit successfully on Stokenet, so the x402 server should validate the payment semantics it relies on rather than assume header equality.
+- Notion publication is currently blocked by expired connector authentication. This repo-local PRD should be copied to Notion once the connector is re-authenticated, and the Linear implementation issue should link back to the Notion page.

--- a/examples/x402/CONTEXT.md
+++ b/examples/x402/CONTEXT.md
@@ -1,0 +1,308 @@
+# x402 Radix Reference Design
+
+The x402 Radix reference design demonstrates agent-paid HTTP resources using Radix Transaction Manifest V2 payment flows.
+
+## Language
+
+**x402 Sponsored Payment**:
+An x402 payment flow where the payer signs a payment Subintent and a facilitator wraps it in a root transaction that pays network fees.
+_Avoid_: Non-sponsored x402 transaction, client-paid gas payment
+
+**x402 Reference Implementation**:
+A runnable server-side example that demonstrates protected-resource settlement for payer-signed Radix Subintents.
+_Avoid_: Design-only reference, protocol notes
+
+**x402 Example Package**:
+The single workspace package under `examples/x402` that contains the Hono server, payment middleware, protected markdown file, and shared example helpers.
+_Avoid_: Split server package, separate middleware package
+
+**x402 Payment Middleware**:
+A Hono middleware that protects a route by issuing x402 payment requirements, validating a payment payload, settling the payment, and allowing the route handler to serve the resource.
+_Avoid_: Standalone payment route, route-specific payment handler
+
+**Protected Route Surface**:
+The public HTTP surface of the example server, limited to routes that either return `402` requirements or serve the protected resource after payment.
+_Avoid_: Public facilitator API, separate verify endpoint, separate settle endpoint
+
+**Protected Markdown Resource**:
+A markdown document served by the Hono route only after an x402 payment has settled.
+_Avoid_: Protected JSON resource, static public markdown
+
+**Protected Markdown File**:
+The local `.md` file read by the protected route after payment succeeds.
+_Avoid_: Inline route content, generated markdown response
+
+**Reusable Payment Middleware**:
+The Hono middleware shape that can protect arbitrary routes while the reference demonstrates it on one markdown route.
+_Avoid_: Single-route payment code, framework package abstraction
+
+**Fixed Route Payment Terms**:
+The static payment configuration attached to the protected markdown route for the v1 reference.
+_Avoid_: Dynamic pricing, request-dependent payment requirements
+
+**Absolute Resource URL**:
+The fully qualified URL of the protected resource used in payment requirements and settlement cache identity.
+_Avoid_: Route-relative resource URL, handler-local path
+
+**Structured Payment Requirements**:
+Machine-readable x402 terms that describe the required Radix payment without asking the payer to trust server-authored transaction manifest text.
+_Avoid_: Arbitrary RTM signing request, template-as-authority
+
+**Payment Subintent Construction**:
+The payer-side step that deterministically builds the x402 payment Subintent from Structured Payment Requirements.
+_Avoid_: Signing server-provided RTM, facilitator-authored payer manifest
+
+**Payer Manifest Construction**:
+The payer-side generation of both payment Subintent RTM and preview root RTM from Structured Payment Requirements, normally through generic `rdx subintent` commands.
+_Avoid_: Server-authored RTM as normal path, template-only construction
+
+**Unit-First Payment Coverage**:
+Deterministic non-live tests for x402 manifest generation, payment hashing, cache identity, config placeholder rejection, and exact Subintent validation.
+_Avoid_: Mainnet-only verification, live-first testing
+
+**Advisory Payment Manifest Template**:
+An optional placeholder RTM example derived from Structured Payment Requirements to help agents render or debug the expected Subintent shape.
+_Avoid_: Canonical payment instruction, signable server manifest
+
+**Advisory Preview Root Manifest Template**:
+An optional placeholder RTM example supplied with payment requirements so capable agents can run best-effort Subintent preview before signing.
+_Avoid_: Mandatory settlement manifest, canonical server root transaction
+
+**Authoritative Payment Payload**:
+The x402 retry payload field containing the signed partial transaction that the facilitator decodes and validates for settlement.
+_Avoid_: Redundant payer metadata, client-asserted subintent hash
+
+**Signed Partial Transaction Inspection**:
+The facilitator-side operation that decodes a signed partial transaction, extracts the Subintent manifest and header, computes its hash, and derives payer details for validation.
+_Avoid_: Trusting HTTP metadata, string-parsing payment payload hints
+
+**Validated Subintent Settlement**:
+The server-side path where a valid signed payment Subintent is accepted only as input to settlement, then wrapped, submitted, and observed by the facilitator.
+_Avoid_: Fire-and-forget payment acceptance, unsigned payment promise
+
+**Server Payment Validation**:
+The facilitator-side validation of a signed payment Subintent and wrapped transaction using static checks and Gateway preview before submission.
+_Avoid_: Payload-shape-only validation, payer allowlist
+
+**Exact Payment Subintent Shape**:
+The required v1 instruction sequence for a sponsored x402 Radix payment Subintent.
+_Avoid_: Equivalent manifest variation, flexible instruction matching
+
+**Payment Release Boundary**:
+The settlement state required before the protected resource is served to the requester.
+_Avoid_: Gateway-submitted boundary, optimistic payment acceptance
+
+**Settlement Record**:
+An example-local record that remembers a successful payment settlement for a signed Subintent and payment requirement pair.
+_Avoid_: Protocol receipt, durable payment ledger
+
+**Settlement Cache Key**:
+A hash derived from the Subintent hash, payment requirements hash, and protected resource URL.
+_Avoid_: Subintent-only cache key, route-only cache key
+
+**Payment Requirements Hash**:
+A canonical hash over the normalized payment semantics, excluding advisory or debug fields.
+_Avoid_: Full response JSON hash, advisory template hash
+
+**Facilitator Notary Binding**:
+The relationship between the facilitator's configured notary key, its virtual signature badge in payment requirements, and the root transaction's signatory notary.
+_Avoid_: Arbitrary parent signer, unbound facilitator identity
+
+**Facilitator Notary Key**:
+The configured notary key used by the facilitator to notarize the sponsored root transaction and satisfy the payer Subintent's parent check.
+_Avoid_: Fee payer account, pay-to account
+
+**Fee Payer Account**:
+The configured account that locks XRD fees for the sponsored root transaction.
+_Avoid_: Facilitator notary identity, merchant account
+
+**Pay-To Account**:
+The configured account that receives the protected-resource payment.
+_Avoid_: Fee payer account, notary account
+
+**Reference Network**:
+The Radix network targeted by the runnable x402 reference implementation.
+_Avoid_: Stokenet-only example, implicit test network
+
+**Mainnet Config Template**:
+An example configuration file with placeholders for every Mainnet account, key, asset, and amount required by the x402 reference.
+_Avoid_: Generated Mainnet defaults, hidden configuration
+
+**Placeholder Rejection**:
+The runtime check that refuses to issue payment requirements or settle payments while any Mainnet config placeholder remains.
+_Avoid_: Best-effort placeholder use, demo fallback values
+
+**Payer rdx Workflow**:
+The generic `rdx subintent prepare` and `rdx subintent build` workflow a payer uses to produce the signed partial transaction consumed by the x402 server.
+_Avoid_: x402-specific CLI command, example-specific agent client
+
+**Signed Subintent Build**:
+The payer-side use of `rdx subintent build` to produce the signed partial transaction for the payment payload.
+_Avoid_: Notarized transaction assembly, root transaction submission
+
+**Payer Payment Signing**:
+The payer's signing step where it signs the prepared Subintent hash before building the x402 payment payload.
+_Avoid_: Server-side payer signing, interactive wallet signing
+
+**Payer Account**:
+The Radix account address selected by the payer as the source of the x402 payment.
+_Avoid_: Server-selected payer account, facilitator payer account
+
+**Valid Payer**:
+Any payer account whose signed Subintent satisfies the payment requirements, passes server validation, and settles successfully.
+_Avoid_: Payer allowlist, pre-approved customer account
+
+**x402 Preview Root Manifest**:
+The best-effort root manifest used by the agent-side preview to exercise facilitator parent binding and payment deposit behavior before signing.
+_Avoid_: Mandatory settlement manifest, naked Subintent preview, unrelated preview transaction
+
+**Preview Root Fallback**:
+The agent-side order for Subintent preview: build a preview root from structured requirements when possible, use an advisory template if needed, and use no-preview only as the last case.
+_Avoid_: Silent preview skip, template-first preview
+
+## Relationships
+
+- An **x402 Sponsored Payment** uses the **Agent-first CLI Wallet** to produce the payer-signed **Subintent** and leaves root transaction wrapping, gas payment, submission, and polling to the facilitator.
+- The **x402 Reference Implementation** exercises the **x402 Sponsored Payment** flow as executable code rather than documentation alone.
+- The **x402 Reference Implementation** lives in one **x402 Example Package**.
+- The Hono server applies **x402 Payment Middleware** to a route that serves a **Protected Markdown Resource**.
+- The example server exposes a **Protected Route Surface** only; facilitator verify and settle operations stay internal to middleware.
+- **x402 Payment Middleware** is implemented as **Reusable Payment Middleware** and demonstrated with a fixed **Protected Markdown Resource** route.
+- The **Protected Markdown Resource** is served from a **Protected Markdown File**.
+- The v1 protected route uses **Fixed Route Payment Terms**.
+- Payment requirements bind to an **Absolute Resource URL**.
+- **Payment Subintent Construction** uses **Structured Payment Requirements** rather than server-provided RTM.
+- The normal path for **Payment Subintent Construction** is **Payer Manifest Construction** through generic `rdx subintent` commands.
+- The **x402 Reference Implementation** uses **Unit-First Payment Coverage** before any live Mainnet path.
+- An **Advisory Payment Manifest Template** may accompany **Structured Payment Requirements**, but the agent must rebuild or verify it from the structured fields before signing.
+- An **Advisory Preview Root Manifest Template** may accompany **Structured Payment Requirements**, but it is only used for best-effort agent preview.
+- The **Authoritative Payment Payload** contains only the signed partial transaction; subintent hash, payer account, expiry, and settlement status are derived by the facilitator.
+- The facilitator uses **Signed Partial Transaction Inspection** to derive payer account, asset, amount, Subintent hash, and expiry from the signed payload.
+- `@radix-effects/tx-tool` should expose a helper for **Signed Partial Transaction Inspection** so the x402 facilitator does not hand-roll signed partial transaction decoding.
+- The facilitator performs **Server Payment Validation** before submitting the sponsored root transaction.
+- **Server Payment Validation** requires the **Exact Payment Subintent Shape**.
+- The server accepts any **Valid Payer**; payer identity is derived and logged, not allowlisted.
+- **x402 Payment Middleware** performs **Validated Subintent Settlement** before treating a payment retry as paid.
+- The **Payment Release Boundary** is Gateway `CommittedSuccess`; `Submitted` is not enough to serve the protected resource.
+- The **x402 Reference Implementation** keeps **Settlement Records** in memory so a retry after `CommittedSuccess` can serve the protected resource without resubmitting the same signed Subintent.
+- Each **Settlement Record** is indexed by a **Settlement Cache Key**.
+- The **Settlement Cache Key** uses a **Payment Requirements Hash** rather than hashing the full `402` response object.
+- An **x402 Sponsored Payment** uses **Facilitator Notary Binding** so the payer Subintent can `VERIFY_PARENT` against the facilitator's virtual signature badge.
+- The **Facilitator Notary Key**, **Fee Payer Account**, and **Pay-To Account** are separate configured roles in the **x402 Reference Implementation**.
+- The **Reference Network** for the **x402 Reference Implementation** is Mainnet.
+- The **x402 Reference Implementation** ships a **Mainnet Config Template** and applies **Placeholder Rejection** at runtime.
+- The payer uses the **Payer rdx Workflow** to create and sign the payment Subintent.
+- The payer uses generic `rdx subintent` commands followed by **Signed Subintent Build**; it does not create, notarize, or submit the facilitator root transaction.
+- The payer owns the **Payer Account** and uses it when building the payment Subintent.
+- The payer performs **Payer Payment Signing** and returns the signature through the rdx signature-file boundary.
+- Key sourcing for **Payer Payment Signing** is internal to the CLI-facing payer environment and out of scope for the x402 reference design.
+- The agent-side preview may supply an **x402 Preview Root Manifest** as the generic `rdx subintent prepare --root-manifest` file.
+- The payer treats Subintent preview as best-effort when it has a suitable **x402 Preview Root Manifest**.
+- The payer follows **Preview Root Fallback** before using no-preview.
+
+## Example Dialogue
+
+> **Dev:** "Should the payer build and submit a complete transaction?"
+> **Domain expert:** "No — the reference path is an **x402 Sponsored Payment**, so the payer signs a payment **Subintent** and the facilitator submits the root transaction."
+
+> **Dev:** "Can the x402 example be a design note without runnable code?"
+> **Domain expert:** "No — the **x402 Reference Implementation** must be executable so the payment flow and settlement boundary are testable."
+
+> **Dev:** "Should the example include an x402-specific client agent?"
+> **Domain expert:** "No — keep the payer side as the generic **Payer rdx Workflow**."
+
+> **Dev:** "Should payment handling live directly inside the markdown route handler?"
+> **Domain expert:** "No — protect the route with **x402 Payment Middleware** and keep the handler focused on serving the **Protected Markdown Resource**."
+
+> **Dev:** "Should the runnable server expose separate `/verify` and `/settle` endpoints?"
+> **Domain expert:** "No — expose only the **Protected Route Surface** and keep facilitator operations internal."
+
+> **Dev:** "Should payment protection be hard-coded into one markdown route?"
+> **Domain expert:** "No — implement **Reusable Payment Middleware** and demonstrate it on a single **Protected Markdown Resource** route."
+
+> **Dev:** "Should the protected markdown be generated inline by the route?"
+> **Domain expert:** "No — serve it from a **Protected Markdown File**."
+
+> **Dev:** "Should payment requirements be dynamically computed per request?"
+> **Domain expert:** "No — use **Fixed Route Payment Terms** for the v1 reference."
+
+> **Dev:** "Can payment requirements bind to a route-relative resource path?"
+> **Domain expert:** "No — bind payment to the **Absolute Resource URL** requested by the payer."
+
+> **Dev:** "Should the server send a Subintent manifest template for the payer to sign?"
+> **Domain expert:** "No — the payer performs **Payment Subintent Construction** from **Structured Payment Requirements** so it does not sign arbitrary server-authored RTM."
+
+> **Dev:** "Should the payer generate both payment and preview manifests from the structured requirements?"
+> **Domain expert:** "Yes — use **Payer Manifest Construction** as the normal path."
+
+> **Dev:** "Can the x402 reference rely on live Mainnet runs for confidence?"
+> **Domain expert:** "No — use **Unit-First Payment Coverage** and keep live Mainnet execution explicitly configured."
+
+> **Dev:** "Can the server include a placeholder manifest template anyway?"
+> **Domain expert:** "Yes, as an **Advisory Payment Manifest Template**, but it is never the authority the payer signs."
+
+> **Dev:** "Can the server include a root manifest template for agent-side preview?"
+> **Domain expert:** "Yes, as an **Advisory Preview Root Manifest Template**, but it is not the canonical settlement transaction."
+
+> **Dev:** "Should the x402 retry payload include payer account and expiry metadata?"
+> **Domain expert:** "No — keep the signed partial transaction as the **Authoritative Payment Payload** and derive metadata during validation."
+
+> **Dev:** "Should the x402 example decode signed partial transactions directly?"
+> **Domain expert:** "No — add a `@radix-effects/tx-tool` helper for **Signed Partial Transaction Inspection** and use that from the facilitator."
+
+> **Dev:** "Can the server accept a signed payment payload after only checking its JSON shape?"
+> **Domain expert:** "No — perform **Server Payment Validation** with static checks and Gateway preview before submission."
+
+> **Dev:** "Can v1 validation accept semantically equivalent payment Subintent manifests?"
+> **Domain expert:** "No — require the **Exact Payment Subintent Shape**."
+
+> **Dev:** "Should the server maintain a payer allowlist?"
+> **Domain expert:** "No — accept any **Valid Payer**."
+
+> **Dev:** "Can the server accept a valid signed Subintent and settle it later?"
+> **Domain expert:** "No — a valid signed Subintent is accepted for **Validated Subintent Settlement**, not as a deferred payment promise."
+
+> **Dev:** "Can the server release markdown after Gateway accepts the transaction submission?"
+> **Domain expert:** "No — the **Payment Release Boundary** is `CommittedSuccess`."
+
+> **Dev:** "Should the reference implementation use a production database for settlement records?"
+> **Domain expert:** "No — keep **Settlement Records** in memory for the runnable example."
+
+> **Dev:** "Can settlement cache entries be keyed only by Subintent hash?"
+> **Domain expert:** "No — use a **Settlement Cache Key** derived from Subintent hash, payment requirements hash, and protected resource URL."
+
+> **Dev:** "Should payment requirements be hashed from the full JSON response?"
+> **Domain expert:** "No — compute the **Payment Requirements Hash** from normalized payment semantics and exclude advisory fields."
+
+> **Dev:** "Can the facilitator use any notary when settling a signed payment Subintent?"
+> **Domain expert:** "No — **Facilitator Notary Binding** ties the requirements badge, Subintent `VERIFY_PARENT`, and root transaction notary together."
+
+> **Dev:** "Can the facilitator notary, fee payer, and merchant recipient be modeled as one account?"
+> **Domain expert:** "No — keep the **Facilitator Notary Key**, **Fee Payer Account**, and **Pay-To Account** as separate roles even if one operator controls them."
+
+> **Dev:** "Should the runnable x402 reference default to Stokenet?"
+> **Domain expert:** "No — the **Reference Network** is Mainnet."
+
+> **Dev:** "Can the Mainnet example run with generated defaults?"
+> **Domain expert:** "No — provide a **Mainnet Config Template** and enforce **Placeholder Rejection** before payment handling."
+
+> **Dev:** "Should the x402 reference implement its own client agent?"
+> **Domain expert:** "No — the payer side is the generic **Payer rdx Workflow**."
+
+> **Dev:** "Should rdx create and submit a full transaction for x402?"
+> **Domain expert:** "No — the payer uses generic `rdx subintent` commands and **Signed Subintent Build**; the server settles the root transaction."
+
+> **Dev:** "Should the server or an interactive wallet sign the x402 payment Subintent?"
+> **Domain expert:** "No — the payer performs **Payer Payment Signing**; key sourcing is internal to the CLI-facing payer environment."
+
+> **Dev:** "Should the server tell the payer which payer account to use?"
+> **Domain expert:** "No — the payer owns the **Payer Account**."
+
+> **Dev:** "Can the payer preview the payment Subintent by itself?"
+> **Domain expert:** "No — use an **x402 Preview Root Manifest** when available so preview executes the Subintent in a realistic sponsored root context."
+
+> **Dev:** "Can the payer use `rdx subintent prepare --no-preview`?"
+> **Domain expert:** "Yes, but only explicitly; the payer should use an **x402 Preview Root Manifest** when it has enough root context."
+
+> **Dev:** "Should the payer skip preview when no advisory root template is provided?"
+> **Domain expert:** "No — follow **Preview Root Fallback** and use no-preview only as the last case."

--- a/examples/x402/package.json
+++ b/examples/x402/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@radix-effects/x402-example",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "server": "tsx src/serverMain.ts",
+    "test": "vitest",
+    "check-types": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@hono/node-server": "^2.0.4",
+    "@radix-effects/tx-tool": "workspace:*",
+    "effect": "catalog:",
+    "hono": "^4.12.23"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/examples/x402/protected/reference.md
+++ b/examples/x402/protected/reference.md
@@ -1,0 +1,3 @@
+# x402 Radix Protected Reference
+
+This markdown file is served only after the x402 Payment Middleware observes a settled Radix sponsored payment.

--- a/examples/x402/src/config.test.ts
+++ b/examples/x402/src/config.test.ts
@@ -1,0 +1,26 @@
+import { Effect } from 'effect';
+import { describe, expect, it } from 'vitest';
+import {
+  ConfigPlaceholderError,
+  mainnetConfigTemplate,
+  validateX402Config,
+} from './config';
+
+describe('Placeholder Rejection', () => {
+  it('rejects the Mainnet config template before runtime use', async () => {
+    const error = await Effect.runPromise(
+      Effect.flip(validateX402Config(mainnetConfigTemplate)),
+    );
+
+    expect(error).toBeInstanceOf(ConfigPlaceholderError);
+    expect(error.placeholderPaths).toEqual([
+      'gatewayBaseUrl',
+      'resourceBaseUrl',
+      'feePayerAccount',
+      'payTo',
+      'facilitatorNotaryBadge',
+      'asset',
+      'intentDiscriminator',
+    ]);
+  });
+});

--- a/examples/x402/src/config.test.ts
+++ b/examples/x402/src/config.test.ts
@@ -1,8 +1,10 @@
 import { Effect } from 'effect';
 import { describe, expect, it } from 'vitest';
 import {
+  ConfigParseError,
   ConfigPlaceholderError,
   mainnetConfigTemplate,
+  parseX402Config,
   validateX402Config,
 } from './config';
 
@@ -22,5 +24,11 @@ describe('Placeholder Rejection', () => {
       'asset',
       'intentDiscriminator',
     ]);
+  });
+
+  it('rejects malformed config JSON with a typed parse error', async () => {
+    const error = await Effect.runPromise(Effect.flip(parseX402Config('{')));
+
+    expect(error).toBeInstanceOf(ConfigParseError);
   });
 });

--- a/examples/x402/src/config.ts
+++ b/examples/x402/src/config.ts
@@ -1,0 +1,77 @@
+import { Data, Effect } from 'effect';
+
+export type X402Config = {
+  networkId: 1;
+  gatewayBaseUrl: string;
+  resourceBaseUrl: string;
+  feePayerAccount: string;
+  payTo: string;
+  facilitatorNotaryBadge: string;
+  asset: string;
+  amount: string;
+  maxTimeoutSeconds: number;
+  intentDiscriminator: string;
+};
+
+export class ConfigPlaceholderError extends Data.TaggedError(
+  'ConfigPlaceholderError',
+)<{
+  placeholderPaths: ReadonlyArray<string>;
+}> {}
+
+export const mainnetConfigTemplate: X402Config = {
+  networkId: 1,
+  gatewayBaseUrl: '<MAINNET_GATEWAY_BASE_URL>',
+  resourceBaseUrl: '<RESOURCE_BASE_URL>',
+  feePayerAccount: '<FEE_PAYER_ACCOUNT>',
+  payTo: '<PAY_TO_ACCOUNT>',
+  facilitatorNotaryBadge: '<FACILITATOR_NOTARY_BADGE>',
+  asset: '<PAYMENT_ASSET>',
+  amount: '1',
+  maxTimeoutSeconds: 60,
+  intentDiscriminator: '<INTENT_DISCRIMINATOR>',
+};
+
+const isPlaceholder = (value: string): boolean =>
+  value.startsWith('<') && value.endsWith('>');
+
+export const validateX402Config = (
+  config: X402Config,
+): Effect.Effect<X402Config, ConfigPlaceholderError> => {
+  const placeholderPaths = [
+    isPlaceholder(config.gatewayBaseUrl) ? 'gatewayBaseUrl' : undefined,
+    isPlaceholder(config.resourceBaseUrl) ? 'resourceBaseUrl' : undefined,
+    isPlaceholder(config.feePayerAccount) ? 'feePayerAccount' : undefined,
+    isPlaceholder(config.payTo) ? 'payTo' : undefined,
+    isPlaceholder(config.facilitatorNotaryBadge)
+      ? 'facilitatorNotaryBadge'
+      : undefined,
+    isPlaceholder(config.asset) ? 'asset' : undefined,
+    isPlaceholder(config.amount) ? 'amount' : undefined,
+    isPlaceholder(config.intentDiscriminator)
+      ? 'intentDiscriminator'
+      : undefined,
+  ].filter((path) => path !== undefined);
+
+  return placeholderPaths.length === 0
+    ? Effect.succeed(config)
+    : Effect.fail(new ConfigPlaceholderError({ placeholderPaths }));
+};
+
+export const paymentRequirementsFromConfig = (input: {
+  config: X402Config;
+  resourceUrl: string;
+}) => ({
+  scheme: 'exact' as const,
+  network: 'radix:mainnet' as const,
+  resourceUrl: input.resourceUrl,
+  payTo: input.config.payTo,
+  asset: input.config.asset,
+  amount: input.config.amount,
+  maxTimeoutSeconds: input.config.maxTimeoutSeconds,
+  extra: {
+    mode: 'sponsored' as const,
+    notaryBadge: input.config.facilitatorNotaryBadge,
+    intentDiscriminator: input.config.intentDiscriminator,
+  },
+});

--- a/examples/x402/src/config.ts
+++ b/examples/x402/src/config.ts
@@ -1,17 +1,24 @@
-import { Data, Effect } from 'effect';
+import { Data, Effect, Schema } from 'effect';
+import type { PaymentRequirements } from './paymentRequirements';
 
-export type X402Config = {
-  networkId: 1;
-  gatewayBaseUrl: string;
-  resourceBaseUrl: string;
-  feePayerAccount: string;
-  payTo: string;
-  facilitatorNotaryBadge: string;
-  asset: string;
-  amount: string;
-  maxTimeoutSeconds: number;
-  intentDiscriminator: string;
-};
+export const X402ConfigSchema = Schema.Struct({
+  networkId: Schema.Literal(1),
+  gatewayBaseUrl: Schema.String,
+  resourceBaseUrl: Schema.String,
+  feePayerAccount: Schema.String,
+  payTo: Schema.String,
+  facilitatorNotaryBadge: Schema.String,
+  asset: Schema.String,
+  amount: Schema.String,
+  maxTimeoutSeconds: Schema.Number,
+  intentDiscriminator: Schema.String,
+});
+
+export type X402Config = typeof X402ConfigSchema.Type;
+
+export class ConfigParseError extends Data.TaggedError('ConfigParseError')<{
+  reason: unknown;
+}> {}
 
 export class ConfigPlaceholderError extends Data.TaggedError(
   'ConfigPlaceholderError',
@@ -35,9 +42,9 @@ export const mainnetConfigTemplate: X402Config = {
 const isPlaceholder = (value: string): boolean =>
   value.startsWith('<') && value.endsWith('>');
 
-export const validateX402Config = (
+export const validateX402Config = Effect.fn('validateX402Config')(function* (
   config: X402Config,
-): Effect.Effect<X402Config, ConfigPlaceholderError> => {
+) {
   const placeholderPaths = [
     isPlaceholder(config.gatewayBaseUrl) ? 'gatewayBaseUrl' : undefined,
     isPlaceholder(config.resourceBaseUrl) ? 'resourceBaseUrl' : undefined,
@@ -53,24 +60,38 @@ export const validateX402Config = (
       : undefined,
   ].filter((path) => path !== undefined);
 
-  return placeholderPaths.length === 0
-    ? Effect.succeed(config)
-    : Effect.fail(new ConfigPlaceholderError({ placeholderPaths }));
-};
+  if (placeholderPaths.length > 0) {
+    return yield* Effect.fail(new ConfigPlaceholderError({ placeholderPaths }));
+  }
+
+  return config;
+});
+
+export const parseX402Config = Effect.fn('parseX402Config')(function* (
+  rawConfig: string,
+) {
+  const config = yield* Schema.decodeUnknown(
+    Schema.parseJson(X402ConfigSchema),
+  )(rawConfig).pipe(
+    Effect.mapError((reason) => new ConfigParseError({ reason })),
+  );
+
+  return yield* validateX402Config(config);
+});
 
 export const paymentRequirementsFromConfig = (input: {
   config: X402Config;
   resourceUrl: string;
-}) => ({
-  scheme: 'exact' as const,
-  network: 'radix:mainnet' as const,
+}): PaymentRequirements => ({
+  scheme: 'exact',
+  network: 'radix:mainnet',
   resourceUrl: input.resourceUrl,
   payTo: input.config.payTo,
   asset: input.config.asset,
   amount: input.config.amount,
   maxTimeoutSeconds: input.config.maxTimeoutSeconds,
   extra: {
-    mode: 'sponsored' as const,
+    mode: 'sponsored',
     notaryBadge: input.config.facilitatorNotaryBadge,
     intentDiscriminator: input.config.intentDiscriminator,
   },

--- a/examples/x402/src/exactRadix.test.ts
+++ b/examples/x402/src/exactRadix.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import {
+  paymentSubintentManifest,
+  previewRootManifest,
+  subintentHashPlaceholder,
+} from './exactRadix';
+import type { PaymentRequirements } from './paymentRequirements';
+
+const requirements: PaymentRequirements = {
+  scheme: 'exact',
+  network: 'radix:mainnet',
+  resourceUrl: 'https://merchant.example/protected/reference.md',
+  payTo: 'account_rdx1282dj2he2pm0qdgrwn9nsymr8v3n2dr59u2rwzfq8t2vrlv9av74j4',
+  asset: 'resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd',
+  amount: '1.5',
+  maxTimeoutSeconds: 60,
+  extra: {
+    mode: 'sponsored',
+    notaryBadge:
+      'resource_rdx1nfxxxxxxxxxxed25sgxxxxxxxxx002236757237xxxxxxxxx3e2cpa:[11111111111111111111111111111111]',
+    intentDiscriminator: '123',
+  },
+};
+
+describe('exact Radix payment manifests', () => {
+  it('builds the exact sponsored payment Subintent instruction sequence', () => {
+    expect(
+      paymentSubintentManifest({
+        requirements,
+        payerAccount:
+          'account_rdx129a9wuey40lducsne6r8e5q7xmt07068gcede0x0nrwtsnehpkf6zh',
+      }),
+    ).toBe(`VERIFY_PARENT
+    Enum<AccessRule::Protected>(
+        Enum<CompositeRequirement::BasicRequirement>(
+            Enum<BasicRequirement::Require>(
+                Enum<ResourceOrNonFungible::NonFungible>(
+                    NonFungibleGlobalId("resource_rdx1nfxxxxxxxxxxed25sgxxxxxxxxx002236757237xxxxxxxxx3e2cpa:[11111111111111111111111111111111]")
+                )
+            )
+        )
+    )
+;
+ASSERT_WORKTOP_IS_EMPTY;
+CALL_METHOD
+    Address("account_rdx129a9wuey40lducsne6r8e5q7xmt07068gcede0x0nrwtsnehpkf6zh")
+    "withdraw"
+    Address("resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd")
+    Decimal("1.5")
+;
+TAKE_ALL_FROM_WORKTOP
+    Address("resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd")
+    Bucket("payment")
+;
+YIELD_TO_PARENT Bucket("payment");`);
+  });
+
+  it('builds preview root manifest with one Subintent hash placeholder', () => {
+    const manifest = previewRootManifest({
+      requirements,
+      feePayerAccount:
+        'account_rdx12fee2he2pm0qdgrwn9nsymr8v3n2dr59u2rwzfq8t2vrlv9av0000',
+    });
+
+    expect(manifest.split(subintentHashPlaceholder)).toHaveLength(2);
+    expect(manifest).toContain('YIELD_TO_CHILD NamedIntent("payment");');
+    expect(manifest).toContain('"try_deposit_or_abort"');
+  });
+});

--- a/examples/x402/src/exactRadix.ts
+++ b/examples/x402/src/exactRadix.ts
@@ -1,0 +1,64 @@
+import type { PaymentRequirements } from './paymentRequirements';
+
+export type PaymentSubintentManifestInput = {
+  requirements: PaymentRequirements;
+  payerAccount: string;
+};
+
+export type PreviewRootManifestInput = {
+  requirements: PaymentRequirements;
+  feePayerAccount: string;
+};
+
+export const subintentHashPlaceholder = '<subintentHash>';
+
+export const paymentSubintentManifest = ({
+  payerAccount,
+  requirements,
+}: PaymentSubintentManifestInput): string => `VERIFY_PARENT
+    Enum<AccessRule::Protected>(
+        Enum<CompositeRequirement::BasicRequirement>(
+            Enum<BasicRequirement::Require>(
+                Enum<ResourceOrNonFungible::NonFungible>(
+                    NonFungibleGlobalId("${requirements.extra.notaryBadge}")
+                )
+            )
+        )
+    )
+;
+ASSERT_WORKTOP_IS_EMPTY;
+CALL_METHOD
+    Address("${payerAccount}")
+    "withdraw"
+    Address("${requirements.asset}")
+    Decimal("${requirements.amount}")
+;
+TAKE_ALL_FROM_WORKTOP
+    Address("${requirements.asset}")
+    Bucket("payment")
+;
+YIELD_TO_PARENT Bucket("payment");`;
+
+export const previewRootManifest = ({
+  feePayerAccount,
+  requirements,
+}: PreviewRootManifestInput): string => `USE_CHILD
+    NamedIntent("payment")
+    Intent("${subintentHashPlaceholder}")
+;
+CALL_METHOD
+    Address("${feePayerAccount}")
+    "lock_fee"
+    Decimal("10")
+;
+YIELD_TO_CHILD NamedIntent("payment");
+TAKE_ALL_FROM_WORKTOP
+    Address("${requirements.asset}")
+    Bucket("payment")
+;
+CALL_METHOD
+    Address("${requirements.payTo}")
+    "try_deposit_or_abort"
+    Bucket("payment")
+    None
+;`;

--- a/examples/x402/src/facilitator.test.ts
+++ b/examples/x402/src/facilitator.test.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 import { describe, expect, it } from 'vitest';
 import { createFacilitatorSettlementBackend } from './facilitator';
 import type { PaymentRequirements } from './paymentRequirements';
@@ -23,30 +24,37 @@ describe('facilitator settlement backend', () => {
     const settle = createFacilitatorSettlementBackend({
       feePayerAccount:
         'account_rdx12fee2he2pm0qdgrwn9nsymr8v3n2dr59u2rwzfq8t2vrlv9av0000',
-      preview: async ({ rootManifest }) => {
-        calls.push('preview');
-        expect(rootManifest).toContain('lock_fee');
-        expect(rootManifest).toContain('YIELD_TO_CHILD NamedIntent("payment")');
-        expect(rootManifest).toContain('Intent("subtxid_rdx1paid")');
-      },
-      submit: async () => {
-        calls.push('submit');
-        return { transactionId: 'txid_rdx1settlement' };
-      },
-      waitForCommittedSuccess: async ({ transactionId }) => {
-        calls.push(`wait:${transactionId}`);
-      },
+      preview: ({ rootManifest }) =>
+        Effect.sync(() => {
+          calls.push('preview');
+          expect(rootManifest).toContain('lock_fee');
+          expect(rootManifest).toContain(
+            'YIELD_TO_CHILD NamedIntent("payment")',
+          );
+          expect(rootManifest).toContain('Intent("subtxid_rdx1paid")');
+        }),
+      submit: () =>
+        Effect.sync(() => {
+          calls.push('submit');
+          return { transactionId: 'txid_rdx1settlement' };
+        }),
+      waitForCommittedSuccess: ({ transactionId }) =>
+        Effect.sync(() => {
+          calls.push(`wait:${transactionId}`);
+        }),
     });
 
     await expect(
-      settle({
-        requirements,
-        resourceUrl: requirements.resourceUrl,
-        signedPartialTransactionHex: '4d220504',
-        payerAccount:
-          'account_rdx129a9wuey40lducsne6r8e5q7xmt07068gcede0x0nrwtsnehpkf6zh',
-        subintentHash: 'subtxid_rdx1paid',
-      }),
+      Effect.runPromise(
+        settle({
+          requirements,
+          resourceUrl: requirements.resourceUrl,
+          signedPartialTransactionHex: '4d220504',
+          payerAccount:
+            'account_rdx129a9wuey40lducsne6r8e5q7xmt07068gcede0x0nrwtsnehpkf6zh',
+          subintentHash: 'subtxid_rdx1paid',
+        }),
+      ),
     ).resolves.toEqual({
       status: 'CommittedSuccess',
       payerAccount:

--- a/examples/x402/src/facilitator.test.ts
+++ b/examples/x402/src/facilitator.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { createFacilitatorSettlementBackend } from './facilitator';
+import type { PaymentRequirements } from './paymentRequirements';
+
+const requirements: PaymentRequirements = {
+  scheme: 'exact',
+  network: 'radix:mainnet',
+  resourceUrl: 'https://merchant.example/protected/reference.md',
+  payTo: 'account_rdx1282dj2he2pm0qdgrwn9nsymr8v3n2dr59u2rwzfq8t2vrlv9av74j4',
+  asset: 'resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd',
+  amount: '1.5',
+  maxTimeoutSeconds: 60,
+  extra: {
+    mode: 'sponsored',
+    notaryBadge: 'notary-badge',
+    intentDiscriminator: '123',
+  },
+};
+
+describe('facilitator settlement backend', () => {
+  it('builds sponsored root manifest and waits for CommittedSuccess', async () => {
+    const calls: string[] = [];
+    const settle = createFacilitatorSettlementBackend({
+      feePayerAccount:
+        'account_rdx12fee2he2pm0qdgrwn9nsymr8v3n2dr59u2rwzfq8t2vrlv9av0000',
+      preview: async ({ rootManifest }) => {
+        calls.push('preview');
+        expect(rootManifest).toContain('lock_fee');
+        expect(rootManifest).toContain('YIELD_TO_CHILD NamedIntent("payment")');
+        expect(rootManifest).toContain('Intent("subtxid_rdx1paid")');
+      },
+      submit: async () => {
+        calls.push('submit');
+        return { transactionId: 'txid_rdx1settlement' };
+      },
+      waitForCommittedSuccess: async ({ transactionId }) => {
+        calls.push(`wait:${transactionId}`);
+      },
+    });
+
+    await expect(
+      settle({
+        requirements,
+        resourceUrl: requirements.resourceUrl,
+        signedPartialTransactionHex: '4d220504',
+        payerAccount:
+          'account_rdx129a9wuey40lducsne6r8e5q7xmt07068gcede0x0nrwtsnehpkf6zh',
+        subintentHash: 'subtxid_rdx1paid',
+      }),
+    ).resolves.toEqual({
+      status: 'CommittedSuccess',
+      payerAccount:
+        'account_rdx129a9wuey40lducsne6r8e5q7xmt07068gcede0x0nrwtsnehpkf6zh',
+      subintentHash: 'subtxid_rdx1paid',
+    });
+    expect(calls).toEqual(['preview', 'submit', 'wait:txid_rdx1settlement']);
+  });
+});

--- a/examples/x402/src/facilitator.ts
+++ b/examples/x402/src/facilitator.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 import type { PaymentRequirements } from './paymentRequirements';
 
 export type ValidatedPaymentSettlementInput = {
@@ -8,17 +9,25 @@ export type ValidatedPaymentSettlementInput = {
   subintentHash: string;
 };
 
+export type FacilitatorSettlementResult = {
+  status: 'CommittedSuccess';
+  payerAccount: string;
+  subintentHash: string;
+};
+
 export type FacilitatorSettlementBackendOptions = {
   feePayerAccount: string;
   preview: (input: {
     rootManifest: string;
     signedPartialTransactionHex: string;
-  }) => Promise<void>;
+  }) => Effect.Effect<void, unknown>;
   submit: (input: {
     rootManifest: string;
     signedPartialTransactionHex: string;
-  }) => Promise<{ transactionId: string }>;
-  waitForCommittedSuccess: (input: { transactionId: string }) => Promise<void>;
+  }) => Effect.Effect<{ transactionId: string }, unknown>;
+  waitForCommittedSuccess: (input: {
+    transactionId: string;
+  }) => Effect.Effect<void, unknown>;
 };
 
 export const sponsoredRootManifest = (input: {
@@ -46,33 +55,34 @@ CALL_METHOD
     None
 ;`;
 
-export const createFacilitatorSettlementBackend =
-  ({
-    feePayerAccount,
-    preview,
-    submit,
-    waitForCommittedSuccess,
-  }: FacilitatorSettlementBackendOptions) =>
-  async (input: ValidatedPaymentSettlementInput) => {
+export const createFacilitatorSettlementBackend = ({
+  feePayerAccount,
+  preview,
+  submit,
+  waitForCommittedSuccess,
+}: FacilitatorSettlementBackendOptions) =>
+  Effect.fn('facilitatorSettlementBackend')(function* (
+    input: ValidatedPaymentSettlementInput,
+  ) {
     const rootManifest = sponsoredRootManifest({
       feePayerAccount,
       requirements: input.requirements,
       subintentHash: input.subintentHash,
     });
 
-    await preview({
+    yield* preview({
       rootManifest,
       signedPartialTransactionHex: input.signedPartialTransactionHex,
     });
-    const { transactionId } = await submit({
+    const { transactionId } = yield* submit({
       rootManifest,
       signedPartialTransactionHex: input.signedPartialTransactionHex,
     });
-    await waitForCommittedSuccess({ transactionId });
+    yield* waitForCommittedSuccess({ transactionId });
 
     return {
-      status: 'CommittedSuccess' as const,
+      status: 'CommittedSuccess',
       payerAccount: input.payerAccount,
       subintentHash: input.subintentHash,
-    };
-  };
+    } satisfies FacilitatorSettlementResult;
+  });

--- a/examples/x402/src/facilitator.ts
+++ b/examples/x402/src/facilitator.ts
@@ -1,0 +1,78 @@
+import type { PaymentRequirements } from './paymentRequirements';
+
+export type ValidatedPaymentSettlementInput = {
+  signedPartialTransactionHex: string;
+  requirements: PaymentRequirements;
+  resourceUrl: string;
+  payerAccount: string;
+  subintentHash: string;
+};
+
+export type FacilitatorSettlementBackendOptions = {
+  feePayerAccount: string;
+  preview: (input: {
+    rootManifest: string;
+    signedPartialTransactionHex: string;
+  }) => Promise<void>;
+  submit: (input: {
+    rootManifest: string;
+    signedPartialTransactionHex: string;
+  }) => Promise<{ transactionId: string }>;
+  waitForCommittedSuccess: (input: { transactionId: string }) => Promise<void>;
+};
+
+export const sponsoredRootManifest = (input: {
+  feePayerAccount: string;
+  requirements: PaymentRequirements;
+  subintentHash: string;
+}) => `USE_CHILD
+    NamedIntent("payment")
+    Intent("${input.subintentHash}")
+;
+CALL_METHOD
+    Address("${input.feePayerAccount}")
+    "lock_fee"
+    Decimal("10")
+;
+YIELD_TO_CHILD NamedIntent("payment");
+TAKE_ALL_FROM_WORKTOP
+    Address("${input.requirements.asset}")
+    Bucket("payment")
+;
+CALL_METHOD
+    Address("${input.requirements.payTo}")
+    "try_deposit_or_abort"
+    Bucket("payment")
+    None
+;`;
+
+export const createFacilitatorSettlementBackend =
+  ({
+    feePayerAccount,
+    preview,
+    submit,
+    waitForCommittedSuccess,
+  }: FacilitatorSettlementBackendOptions) =>
+  async (input: ValidatedPaymentSettlementInput) => {
+    const rootManifest = sponsoredRootManifest({
+      feePayerAccount,
+      requirements: input.requirements,
+      subintentHash: input.subintentHash,
+    });
+
+    await preview({
+      rootManifest,
+      signedPartialTransactionHex: input.signedPartialTransactionHex,
+    });
+    const { transactionId } = await submit({
+      rootManifest,
+      signedPartialTransactionHex: input.signedPartialTransactionHex,
+    });
+    await waitForCommittedSuccess({ transactionId });
+
+    return {
+      status: 'CommittedSuccess' as const,
+      payerAccount: input.payerAccount,
+      subintentHash: input.subintentHash,
+    };
+  };

--- a/examples/x402/src/paymentMiddleware.test.ts
+++ b/examples/x402/src/paymentMiddleware.test.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 import { Hono } from 'hono';
 import { describe, expect, it } from 'vitest';
 import { createX402PaymentMiddleware } from './paymentMiddleware';
@@ -49,9 +50,7 @@ describe('x402 Payment Middleware', () => {
       '/protected/reference.md',
       createX402PaymentMiddleware({
         requirements,
-        settlePayment: async () => ({
-          status: 'Submitted',
-        }),
+        settlePayment: () => Effect.succeed({ status: 'Submitted' }),
       }),
       (context) => context.text('paid resource'),
     );
@@ -72,6 +71,29 @@ describe('x402 Payment Middleware', () => {
     });
   });
 
+  it('returns 402 when the payment payload cannot be decoded', async () => {
+    const app = new Hono();
+
+    app.get(
+      '/protected/reference.md',
+      createX402PaymentMiddleware({
+        requirements,
+      }),
+      (context) => context.text('paid resource'),
+    );
+
+    const response = await app.request('/protected/reference.md', {
+      headers: {
+        'X-PAYMENT': '{',
+      },
+    });
+
+    expect(response.status).toBe(402);
+    expect(await response.json()).toEqual({
+      error: 'invalid_payment_payload',
+    });
+  });
+
   it('reuses in-memory Settlement Records after CommittedSuccess', async () => {
     const app = new Hono();
     let settlementAttempts = 0;
@@ -80,12 +102,12 @@ describe('x402 Payment Middleware', () => {
       '/protected/reference.md',
       createX402PaymentMiddleware({
         requirements,
-        settlePayment: async () => {
+        settlePayment: () => {
           settlementAttempts += 1;
-          return {
+          return Effect.succeed({
             status: 'CommittedSuccess',
             subintentHash: 'subtxid_rdx1paid',
-          };
+          });
         },
       }),
       (context) => context.text('paid resource'),

--- a/examples/x402/src/paymentMiddleware.test.ts
+++ b/examples/x402/src/paymentMiddleware.test.ts
@@ -1,0 +1,111 @@
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+import { createX402PaymentMiddleware } from './paymentMiddleware';
+import type { PaymentRequirements } from './paymentRequirements';
+
+const requirements: PaymentRequirements = {
+  scheme: 'exact',
+  network: 'radix:mainnet',
+  resourceUrl: 'https://merchant.example/protected/reference.md',
+  payTo: 'account_rdx1282dj2he2pm0qdgrwn9nsymr8v3n2dr59u2rwzfq8t2vrlv9av74j4',
+  asset: 'resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd',
+  amount: '1.5',
+  maxTimeoutSeconds: 60,
+  extra: {
+    mode: 'sponsored',
+    notaryBadge: 'notary-badge',
+    intentDiscriminator: '123',
+  },
+};
+
+describe('x402 Payment Middleware', () => {
+  it('returns 402 Structured Payment Requirements when payment is missing', async () => {
+    const app = new Hono();
+
+    app.get(
+      '/protected/reference.md',
+      createX402PaymentMiddleware({ requirements }),
+      (context) => context.text('paid resource'),
+    );
+
+    const response = await app.request('/protected/reference.md');
+
+    expect(response.status).toBe(402);
+    expect(await response.json()).toEqual({
+      x402Version: 2,
+      accepts: [
+        {
+          ...requirements,
+          paymentRequirementsHash: expect.any(String),
+        },
+      ],
+    });
+  });
+
+  it('does not serve the protected resource when settlement is not CommittedSuccess', async () => {
+    const app = new Hono();
+
+    app.get(
+      '/protected/reference.md',
+      createX402PaymentMiddleware({
+        requirements,
+        settlePayment: async () => ({
+          status: 'Submitted',
+        }),
+      }),
+      (context) => context.text('paid resource'),
+    );
+
+    const response = await app.request('/protected/reference.md', {
+      headers: {
+        'X-PAYMENT': JSON.stringify({
+          x402Version: 2,
+          payload: { transaction: 'signed-partial-transaction-hex' },
+        }),
+      },
+    });
+
+    expect(response.status).toBe(402);
+    expect(await response.json()).toEqual({
+      error: 'payment_not_settled',
+      paymentStatus: 'Submitted',
+    });
+  });
+
+  it('reuses in-memory Settlement Records after CommittedSuccess', async () => {
+    const app = new Hono();
+    let settlementAttempts = 0;
+
+    app.get(
+      '/protected/reference.md',
+      createX402PaymentMiddleware({
+        requirements,
+        settlePayment: async () => {
+          settlementAttempts += 1;
+          return {
+            status: 'CommittedSuccess',
+            subintentHash: 'subtxid_rdx1paid',
+          };
+        },
+      }),
+      (context) => context.text('paid resource'),
+    );
+
+    const request = {
+      headers: {
+        'X-PAYMENT': JSON.stringify({
+          x402Version: 2,
+          payload: { transaction: 'signed-partial-transaction-hex' },
+        }),
+      },
+    };
+
+    expect((await app.request('/protected/reference.md', request)).status).toBe(
+      200,
+    );
+    expect((await app.request('/protected/reference.md', request)).status).toBe(
+      200,
+    );
+    expect(settlementAttempts).toBe(1);
+  });
+});

--- a/examples/x402/src/paymentMiddleware.ts
+++ b/examples/x402/src/paymentMiddleware.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 import type { MiddlewareHandler } from 'hono';
 import { parseX402PaymentHeader } from './paymentPayload';
 import {
@@ -7,7 +8,7 @@ import {
 import { settlementCacheKey } from './settlementCache';
 
 type SettlementResult =
-  | { status: 'CommittedSuccess'; subintentHash: string }
+  | { status: 'CommittedSuccess'; subintentHash?: string }
   | { status: string; subintentHash?: string };
 
 export type X402PaymentMiddlewareOptions = {
@@ -16,7 +17,7 @@ export type X402PaymentMiddlewareOptions = {
     signedPartialTransactionHex: string;
     requirements: PaymentRequirements;
     resourceUrl: string;
-  }) => Promise<SettlementResult>;
+  }) => Effect.Effect<SettlementResult, unknown>;
 };
 
 export const createX402PaymentMiddleware = ({
@@ -26,64 +27,96 @@ export const createX402PaymentMiddleware = ({
   const settlementRecords = new Set<string>();
   const payloadSettlementKeys = new Map<string, string>();
 
-  return async (context, next) => {
-    const paymentPayload = context.req.header('X-PAYMENT');
+  return (context, next) =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const paymentPayload = context.req.header('X-PAYMENT');
 
-    if (paymentPayload === undefined) {
-      return context.json(
-        {
-          x402Version: 2,
-          accepts: [
+        if (paymentPayload === undefined) {
+          return context.json(
             {
-              ...requirements,
-              paymentRequirementsHash: paymentRequirementsHash(requirements),
+              x402Version: 2,
+              accepts: [
+                {
+                  ...requirements,
+                  paymentRequirementsHash:
+                    paymentRequirementsHash(requirements),
+                },
+              ],
             },
-          ],
-        },
-        402,
-      );
-    }
+            402,
+          );
+        }
 
-    const parsedPaymentPayload = parseX402PaymentHeader(paymentPayload);
-    const existingSettlementKey = payloadSettlementKeys.get(
-      parsedPaymentPayload.transaction,
+        const parsedPaymentPayload =
+          yield* parseX402PaymentHeader(paymentPayload);
+        const existingSettlementKey = payloadSettlementKeys.get(
+          parsedPaymentPayload.transaction,
+        );
+
+        if (
+          existingSettlementKey !== undefined &&
+          settlementRecords.has(existingSettlementKey)
+        ) {
+          yield* Effect.promise(() => next());
+          return;
+        }
+
+        const pendingCacheKey = (subintentHash: string) =>
+          settlementCacheKey({
+            subintentHash,
+            requirements,
+            resourceUrl: requirements.resourceUrl,
+          });
+        const settlementEffect: Effect.Effect<SettlementResult> =
+          settlePayment === undefined
+            ? Effect.succeed({
+                status: 'MissingSettlementHandler',
+              } satisfies SettlementResult)
+            : settlePayment({
+                signedPartialTransactionHex: parsedPaymentPayload.transaction,
+                requirements,
+                resourceUrl: requirements.resourceUrl,
+              }).pipe(
+                Effect.catchAll(() =>
+                  Effect.succeed({
+                    status: 'SettlementFailed',
+                  } satisfies SettlementResult),
+                ),
+              );
+        const settlement = yield* settlementEffect;
+
+        if (settlement.status !== 'CommittedSuccess') {
+          return context.json(
+            {
+              error: 'payment_not_settled',
+              paymentStatus: settlement.status,
+            },
+            402,
+          );
+        }
+
+        if (
+          'subintentHash' in settlement &&
+          settlement.subintentHash !== undefined
+        ) {
+          const cacheKey = pendingCacheKey(settlement.subintentHash);
+          settlementRecords.add(cacheKey);
+          payloadSettlementKeys.set(parsedPaymentPayload.transaction, cacheKey);
+        }
+
+        yield* Effect.promise(() => next());
+      }).pipe(
+        Effect.catchTag('InvalidPaymentPayloadError', () =>
+          Effect.succeed(
+            context.json(
+              {
+                error: 'invalid_payment_payload',
+              },
+              402,
+            ),
+          ),
+        ),
+      ),
     );
-    if (
-      existingSettlementKey !== undefined &&
-      settlementRecords.has(existingSettlementKey)
-    ) {
-      await next();
-      return;
-    }
-
-    const pendingCacheKey = (subintentHash: string) =>
-      settlementCacheKey({
-        subintentHash,
-        requirements,
-        resourceUrl: requirements.resourceUrl,
-      });
-    const settlement = await settlePayment?.({
-      signedPartialTransactionHex: parsedPaymentPayload.transaction,
-      requirements,
-      resourceUrl: requirements.resourceUrl,
-    });
-
-    if (settlement?.status !== 'CommittedSuccess') {
-      return context.json(
-        {
-          error: 'payment_not_settled',
-          paymentStatus: settlement?.status ?? 'MissingSettlementHandler',
-        },
-        402,
-      );
-    }
-
-    if (settlement.subintentHash !== undefined) {
-      const cacheKey = pendingCacheKey(settlement.subintentHash);
-      settlementRecords.add(cacheKey);
-      payloadSettlementKeys.set(parsedPaymentPayload.transaction, cacheKey);
-    }
-
-    await next();
-  };
 };

--- a/examples/x402/src/paymentMiddleware.ts
+++ b/examples/x402/src/paymentMiddleware.ts
@@ -1,0 +1,89 @@
+import type { MiddlewareHandler } from 'hono';
+import { parseX402PaymentHeader } from './paymentPayload';
+import {
+  type PaymentRequirements,
+  paymentRequirementsHash,
+} from './paymentRequirements';
+import { settlementCacheKey } from './settlementCache';
+
+type SettlementResult =
+  | { status: 'CommittedSuccess'; subintentHash: string }
+  | { status: string; subintentHash?: string };
+
+export type X402PaymentMiddlewareOptions = {
+  requirements: PaymentRequirements;
+  settlePayment?: (input: {
+    signedPartialTransactionHex: string;
+    requirements: PaymentRequirements;
+    resourceUrl: string;
+  }) => Promise<SettlementResult>;
+};
+
+export const createX402PaymentMiddleware = ({
+  requirements,
+  settlePayment,
+}: X402PaymentMiddlewareOptions): MiddlewareHandler => {
+  const settlementRecords = new Set<string>();
+  const payloadSettlementKeys = new Map<string, string>();
+
+  return async (context, next) => {
+    const paymentPayload = context.req.header('X-PAYMENT');
+
+    if (paymentPayload === undefined) {
+      return context.json(
+        {
+          x402Version: 2,
+          accepts: [
+            {
+              ...requirements,
+              paymentRequirementsHash: paymentRequirementsHash(requirements),
+            },
+          ],
+        },
+        402,
+      );
+    }
+
+    const parsedPaymentPayload = parseX402PaymentHeader(paymentPayload);
+    const existingSettlementKey = payloadSettlementKeys.get(
+      parsedPaymentPayload.transaction,
+    );
+    if (
+      existingSettlementKey !== undefined &&
+      settlementRecords.has(existingSettlementKey)
+    ) {
+      await next();
+      return;
+    }
+
+    const pendingCacheKey = (subintentHash: string) =>
+      settlementCacheKey({
+        subintentHash,
+        requirements,
+        resourceUrl: requirements.resourceUrl,
+      });
+    const settlement = await settlePayment?.({
+      signedPartialTransactionHex: parsedPaymentPayload.transaction,
+      requirements,
+      resourceUrl: requirements.resourceUrl,
+    });
+
+    if (settlement?.status !== 'CommittedSuccess') {
+      return context.json(
+        {
+          error: 'payment_not_settled',
+          paymentStatus: settlement?.status ?? 'MissingSettlementHandler',
+        },
+        402,
+      );
+    }
+
+    if (settlement.subintentHash !== undefined) {
+      const cacheKey = pendingCacheKey(settlement.subintentHash);
+      settlementRecords.add(cacheKey);
+      payloadSettlementKeys.set(parsedPaymentPayload.transaction, cacheKey);
+    }
+
+    await next();
+  };
+};

--- a/examples/x402/src/paymentPayload.test.ts
+++ b/examples/x402/src/paymentPayload.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { parseX402PaymentHeader } from './paymentPayload';
+
+describe('x402 payment payload', () => {
+  it('extracts the signed partial transaction from PaymentPayload.payload.transaction', () => {
+    expect(
+      parseX402PaymentHeader(
+        JSON.stringify({
+          x402Version: 2,
+          payload: {
+            transaction: '4d220504',
+          },
+        }),
+      ),
+    ).toEqual({
+      transaction: '4d220504',
+    });
+  });
+});

--- a/examples/x402/src/paymentPayload.test.ts
+++ b/examples/x402/src/paymentPayload.test.ts
@@ -1,19 +1,31 @@
+import { Effect } from 'effect';
 import { describe, expect, it } from 'vitest';
-import { parseX402PaymentHeader } from './paymentPayload';
+import {
+  InvalidPaymentPayloadError,
+  parseX402PaymentHeader,
+} from './paymentPayload';
 
 describe('x402 payment payload', () => {
-  it('extracts the signed partial transaction from PaymentPayload.payload.transaction', () => {
-    expect(
-      parseX402PaymentHeader(
-        JSON.stringify({
-          x402Version: 2,
-          payload: {
-            transaction: '4d220504',
-          },
-        }),
+  it('extracts the signed partial transaction from PaymentPayload.payload.transaction', async () => {
+    await expect(
+      Effect.runPromise(
+        parseX402PaymentHeader(
+          JSON.stringify({
+            x402Version: 2,
+            payload: {
+              transaction: '4d220504',
+            },
+          }),
+        ),
       ),
-    ).toEqual({
+    ).resolves.toEqual({
       transaction: '4d220504',
     });
+  });
+
+  it('fails malformed payloads with a typed error', async () => {
+    await expect(
+      Effect.runPromise(Effect.flip(parseX402PaymentHeader('{'))),
+    ).resolves.toBeInstanceOf(InvalidPaymentPayloadError);
   });
 });

--- a/examples/x402/src/paymentPayload.ts
+++ b/examples/x402/src/paymentPayload.ts
@@ -1,0 +1,23 @@
+export type ParsedPaymentPayload = {
+  transaction: string;
+};
+
+export const parseX402PaymentHeader = (
+  headerValue: string,
+): ParsedPaymentPayload => {
+  const parsed = JSON.parse(headerValue) as unknown;
+
+  if (
+    typeof parsed === 'object' &&
+    parsed !== null &&
+    'payload' in parsed &&
+    typeof parsed.payload === 'object' &&
+    parsed.payload !== null &&
+    'transaction' in parsed.payload &&
+    typeof parsed.payload.transaction === 'string'
+  ) {
+    return { transaction: parsed.payload.transaction };
+  }
+
+  throw new Error('Invalid x402 payment payload');
+};

--- a/examples/x402/src/paymentPayload.ts
+++ b/examples/x402/src/paymentPayload.ts
@@ -1,23 +1,29 @@
+import { Data, Effect, Schema } from 'effect';
+
+const X402PaymentHeaderSchema = Schema.Struct({
+  payload: Schema.Struct({
+    transaction: Schema.String,
+  }),
+});
+
 export type ParsedPaymentPayload = {
   transaction: string;
 };
 
-export const parseX402PaymentHeader = (
-  headerValue: string,
-): ParsedPaymentPayload => {
-  const parsed = JSON.parse(headerValue) as unknown;
+export class InvalidPaymentPayloadError extends Data.TaggedError(
+  'InvalidPaymentPayloadError',
+)<{
+  reason: unknown;
+}> {}
 
-  if (
-    typeof parsed === 'object' &&
-    parsed !== null &&
-    'payload' in parsed &&
-    typeof parsed.payload === 'object' &&
-    parsed.payload !== null &&
-    'transaction' in parsed.payload &&
-    typeof parsed.payload.transaction === 'string'
-  ) {
-    return { transaction: parsed.payload.transaction };
-  }
-
-  throw new Error('Invalid x402 payment payload');
-};
+export const parseX402PaymentHeader = Effect.fn('parseX402PaymentHeader')(
+  (
+    headerValue: string,
+  ): Effect.Effect<ParsedPaymentPayload, InvalidPaymentPayloadError> =>
+    Schema.decodeUnknown(Schema.parseJson(X402PaymentHeaderSchema))(
+      headerValue,
+    ).pipe(
+      Effect.mapError((reason) => new InvalidPaymentPayloadError({ reason })),
+      Effect.map(({ payload }) => ({ transaction: payload.transaction })),
+    ),
+);

--- a/examples/x402/src/paymentRequirements.test.ts
+++ b/examples/x402/src/paymentRequirements.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type PaymentRequirements,
+  paymentRequirementsHash,
+} from './paymentRequirements';
+
+const requirements: PaymentRequirements = {
+  scheme: 'exact',
+  network: 'radix:mainnet',
+  resourceUrl: 'https://merchant.example/protected/reference.md',
+  payTo: 'account_rdx1282dj2he2pm0qdgrwn9nsymr8v3n2dr59u2rwzfq8t2vrlv9av74j4',
+  asset: 'resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd',
+  amount: '1.5',
+  maxTimeoutSeconds: 60,
+  extra: {
+    mode: 'sponsored',
+    notaryBadge: 'notary-badge',
+    intentDiscriminator: '123',
+  },
+  advisoryPaymentManifestTemplate: 'manifest version a',
+  advisoryPreviewRootManifestTemplate: 'preview version a',
+};
+
+describe('Payment Requirements Hash', () => {
+  it('is stable when only advisory templates change', () => {
+    const changedAdvisoryTemplates: PaymentRequirements = {
+      ...requirements,
+      advisoryPaymentManifestTemplate: 'manifest version b',
+      advisoryPreviewRootManifestTemplate: 'preview version b',
+    };
+
+    expect(paymentRequirementsHash(changedAdvisoryTemplates)).toBe(
+      paymentRequirementsHash(requirements),
+    );
+  });
+});

--- a/examples/x402/src/paymentRequirements.ts
+++ b/examples/x402/src/paymentRequirements.ts
@@ -1,0 +1,39 @@
+import { createHash } from 'node:crypto';
+
+export type PaymentRequirements = {
+  scheme: 'exact';
+  network: 'radix:mainnet';
+  resourceUrl: string;
+  payTo: string;
+  asset: string;
+  amount: string;
+  maxTimeoutSeconds: number;
+  extra: {
+    mode: 'sponsored';
+    notaryBadge: string;
+    intentDiscriminator: string;
+  };
+  advisoryPaymentManifestTemplate?: string;
+  advisoryPreviewRootManifestTemplate?: string;
+};
+
+export const paymentRequirementsHash = (
+  requirements: PaymentRequirements,
+): string => {
+  const canonicalSemanticFields = [
+    ['scheme', requirements.scheme],
+    ['network', requirements.network],
+    ['resourceUrl', requirements.resourceUrl],
+    ['payTo', requirements.payTo],
+    ['asset', requirements.asset],
+    ['amount', requirements.amount],
+    ['maxTimeoutSeconds', requirements.maxTimeoutSeconds],
+    ['extra.mode', requirements.extra.mode],
+    ['extra.notaryBadge', requirements.extra.notaryBadge],
+    ['extra.intentDiscriminator', requirements.extra.intentDiscriminator],
+  ];
+
+  return createHash('sha256')
+    .update(JSON.stringify(canonicalSemanticFields))
+    .digest('hex');
+};

--- a/examples/x402/src/paymentValidation.test.ts
+++ b/examples/x402/src/paymentValidation.test.ts
@@ -1,0 +1,96 @@
+import { Effect } from 'effect';
+import { describe, expect, it } from 'vitest';
+import { paymentSubintentManifest } from './exactRadix';
+import type { PaymentRequirements } from './paymentRequirements';
+import {
+  ExactPaymentSubintentValidationError,
+  validateExactPaymentSubintent,
+} from './paymentValidation';
+
+const requirements: PaymentRequirements = {
+  scheme: 'exact',
+  network: 'radix:mainnet',
+  resourceUrl: 'https://merchant.example/protected/reference.md',
+  payTo: 'account_rdx1282dj2he2pm0qdgrwn9nsymr8v3n2dr59u2rwzfq8t2vrlv9av74j4',
+  asset: 'resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd',
+  amount: '1.5',
+  maxTimeoutSeconds: 60,
+  extra: {
+    mode: 'sponsored',
+    notaryBadge: 'notary-badge',
+    intentDiscriminator: '123',
+  },
+};
+
+const inspection = {
+  rootSubintentHash: {
+    id: 'subtxid_rdx1valid',
+    hex: 'aa',
+  },
+  nonRootSubintentCount: 0,
+  rootSubintentSignatures: [
+    {
+      curve: 'Ed25519' as const,
+      signature: '22'.repeat(64),
+      publicKey: '11'.repeat(32),
+    },
+  ],
+  rootSubintent: {
+    intentCore: {
+      header: {
+        networkId: 1,
+        startEpochInclusive: 1,
+        endEpochExclusive: 10,
+        intentDiscriminator: 123,
+      },
+      instructions: paymentSubintentManifest({
+        requirements,
+        payerAccount:
+          'account_rdx129a9wuey40lducsne6r8e5q7xmt07068gcede0x0nrwtsnehpkf6zh',
+      }),
+    },
+  },
+};
+
+describe('Exact Payment Subintent validation', () => {
+  it('accepts the exact sponsored payment Subintent shape and derives payer details', async () => {
+    const result = await Effect.runPromise(
+      validateExactPaymentSubintent({
+        inspection,
+        requirements,
+      }),
+    );
+
+    expect(result).toEqual({
+      payerAccount:
+        'account_rdx129a9wuey40lducsne6r8e5q7xmt07068gcede0x0nrwtsnehpkf6zh',
+      subintentHash: 'subtxid_rdx1valid',
+    });
+  });
+
+  it('rejects variants from the exact sponsored payment Subintent shape', async () => {
+    const error = await Effect.runPromise(
+      Effect.flip(
+        validateExactPaymentSubintent({
+          requirements,
+          inspection: {
+            ...inspection,
+            rootSubintent: {
+              intentCore: {
+                ...inspection.rootSubintent.intentCore,
+                instructions:
+                  inspection.rootSubintent.intentCore.instructions.replace(
+                    'Decimal("1.5")',
+                    'Decimal("2")',
+                  ),
+              },
+            },
+          },
+        }),
+      ),
+    );
+
+    expect(error).toBeInstanceOf(ExactPaymentSubintentValidationError);
+    expect(error.code).toBe('NON_EXACT_PAYMENT_SUBINTENT');
+  });
+});

--- a/examples/x402/src/paymentValidation.test.ts
+++ b/examples/x402/src/paymentValidation.test.ts
@@ -4,6 +4,7 @@ import { paymentSubintentManifest } from './exactRadix';
 import type { PaymentRequirements } from './paymentRequirements';
 import {
   ExactPaymentSubintentValidationError,
+  type PaymentSubintentInspection,
   validateExactPaymentSubintent,
 } from './paymentValidation';
 
@@ -22,7 +23,7 @@ const requirements: PaymentRequirements = {
   },
 };
 
-const inspection = {
+const inspection: PaymentSubintentInspection = {
   rootSubintentHash: {
     id: 'subtxid_rdx1valid',
     hex: 'aa',
@@ -30,7 +31,7 @@ const inspection = {
   nonRootSubintentCount: 0,
   rootSubintentSignatures: [
     {
-      curve: 'Ed25519' as const,
+      curve: 'Ed25519',
       signature: '22'.repeat(64),
       publicKey: '11'.repeat(32),
     },
@@ -39,8 +40,6 @@ const inspection = {
     intentCore: {
       header: {
         networkId: 1,
-        startEpochInclusive: 1,
-        endEpochExclusive: 10,
         intentDiscriminator: 123,
       },
       instructions: paymentSubintentManifest({

--- a/examples/x402/src/paymentValidation.ts
+++ b/examples/x402/src/paymentValidation.ts
@@ -40,69 +40,79 @@ const normalizeManifest = (manifest: string) =>
 
 const payerAccountPattern = /CALL_METHOD\s+Address\("([^"]+)"\)\s+"withdraw"/;
 
-export const validateExactPaymentSubintent = (input: {
+export const validateExactPaymentSubintent = Effect.fn(
+  'validateExactPaymentSubintent',
+)(function* (input: {
   inspection: PaymentSubintentInspection;
   requirements: PaymentRequirements;
-}): Effect.Effect<
-  { payerAccount: string; subintentHash: string },
-  ExactPaymentSubintentValidationError
-> =>
-  Effect.gen(function* () {
-    if (input.inspection.rootSubintent.intentCore.header.networkId !== 1) {
-      return yield* new ExactPaymentSubintentValidationError({
+}) {
+  if (input.inspection.rootSubintent.intentCore.header.networkId !== 1) {
+    return yield* Effect.fail(
+      new ExactPaymentSubintentValidationError({
         code: 'UNSUPPORTED_NETWORK',
-      });
-    }
+      }),
+    );
+  }
 
-    if (
-      input.inspection.rootSubintent.intentCore.header.intentDiscriminator !==
-      Number(input.requirements.extra.intentDiscriminator)
-    ) {
-      return yield* new ExactPaymentSubintentValidationError({
+  if (
+    input.inspection.rootSubintent.intentCore.header.intentDiscriminator !==
+    Number(input.requirements.extra.intentDiscriminator)
+  ) {
+    return yield* Effect.fail(
+      new ExactPaymentSubintentValidationError({
         code: 'NON_EXACT_PAYMENT_SUBINTENT',
-      });
-    }
+      }),
+    );
+  }
 
-    if (input.inspection.rootSubintentSignatures.length === 0) {
-      return yield* new ExactPaymentSubintentValidationError({
+  if (input.inspection.rootSubintentSignatures.length === 0) {
+    return yield* Effect.fail(
+      new ExactPaymentSubintentValidationError({
         code: 'MISSING_SIGNATURE',
-      });
-    }
+      }),
+    );
+  }
 
-    if (input.inspection.nonRootSubintentCount !== 0) {
-      return yield* new ExactPaymentSubintentValidationError({
+  if (input.inspection.nonRootSubintentCount !== 0) {
+    return yield* Effect.fail(
+      new ExactPaymentSubintentValidationError({
         code: 'NESTED_SUBINTENTS_UNSUPPORTED',
-      });
-    }
+      }),
+    );
+  }
 
-    const payerAccount = payerAccountPattern.exec(
-      input.inspection.rootSubintent.intentCore.instructions,
-    )?.[1];
+  const payerAccount = payerAccountPattern.exec(
+    input.inspection.rootSubintent.intentCore.instructions,
+  )?.[1];
 
-    if (payerAccount === undefined) {
-      return yield* new ExactPaymentSubintentValidationError({
+  if (payerAccount === undefined) {
+    return yield* Effect.fail(
+      new ExactPaymentSubintentValidationError({
         code: 'PAYER_ACCOUNT_NOT_FOUND',
-      });
-    }
+      }),
+    );
+  }
 
-    const expectedManifest = paymentSubintentManifest({
-      requirements: input.requirements,
-      payerAccount,
-    });
-
-    if (
-      normalizeManifest(expectedManifest) !==
-      normalizeManifest(input.inspection.rootSubintent.intentCore.instructions)
-    ) {
-      return yield* new ExactPaymentSubintentValidationError({
-        code: 'NON_EXACT_PAYMENT_SUBINTENT',
-      });
-    }
-
-    return {
-      payerAccount,
-      subintentHash:
-        input.inspection.rootSubintentHash.id ??
-        input.inspection.rootSubintentHash.hex,
-    };
+  const expectedManifest = paymentSubintentManifest({
+    requirements: input.requirements,
+    payerAccount,
   });
+
+  if (
+    normalizeManifest(expectedManifest) !==
+    normalizeManifest(input.inspection.rootSubintent.intentCore.instructions)
+  ) {
+    return yield* Effect.fail(
+      new ExactPaymentSubintentValidationError({
+        code: 'NON_EXACT_PAYMENT_SUBINTENT',
+      }),
+    );
+  }
+
+  return {
+    payerAccount,
+    subintentHash:
+      input.inspection.rootSubintentHash.id ??
+      input.inspection.rootSubintentHash.hex,
+  };
+});

--- a/examples/x402/src/paymentValidation.ts
+++ b/examples/x402/src/paymentValidation.ts
@@ -1,0 +1,108 @@
+import { Data, Effect } from 'effect';
+import { paymentSubintentManifest } from './exactRadix';
+import type { PaymentRequirements } from './paymentRequirements';
+
+export type PaymentSubintentInspection = {
+  rootSubintentHash: {
+    id: string | null;
+    hex: string;
+  };
+  nonRootSubintentCount: number;
+  rootSubintentSignatures: ReadonlyArray<{
+    curve: 'Ed25519';
+    signature: string;
+    publicKey: string;
+  }>;
+  rootSubintent: {
+    intentCore: {
+      header: {
+        networkId: number;
+        intentDiscriminator: number;
+      };
+      instructions: string;
+    };
+  };
+};
+
+export class ExactPaymentSubintentValidationError extends Data.TaggedError(
+  'ExactPaymentSubintentValidationError',
+)<{
+  code:
+    | 'UNSUPPORTED_NETWORK'
+    | 'MISSING_SIGNATURE'
+    | 'NESTED_SUBINTENTS_UNSUPPORTED'
+    | 'PAYER_ACCOUNT_NOT_FOUND'
+    | 'NON_EXACT_PAYMENT_SUBINTENT';
+}> {}
+
+const normalizeManifest = (manifest: string) =>
+  manifest.trim().replace(/\s+/g, ' ');
+
+const payerAccountPattern = /CALL_METHOD\s+Address\("([^"]+)"\)\s+"withdraw"/;
+
+export const validateExactPaymentSubintent = (input: {
+  inspection: PaymentSubintentInspection;
+  requirements: PaymentRequirements;
+}): Effect.Effect<
+  { payerAccount: string; subintentHash: string },
+  ExactPaymentSubintentValidationError
+> =>
+  Effect.gen(function* () {
+    if (input.inspection.rootSubintent.intentCore.header.networkId !== 1) {
+      return yield* new ExactPaymentSubintentValidationError({
+        code: 'UNSUPPORTED_NETWORK',
+      });
+    }
+
+    if (
+      input.inspection.rootSubintent.intentCore.header.intentDiscriminator !==
+      Number(input.requirements.extra.intentDiscriminator)
+    ) {
+      return yield* new ExactPaymentSubintentValidationError({
+        code: 'NON_EXACT_PAYMENT_SUBINTENT',
+      });
+    }
+
+    if (input.inspection.rootSubintentSignatures.length === 0) {
+      return yield* new ExactPaymentSubintentValidationError({
+        code: 'MISSING_SIGNATURE',
+      });
+    }
+
+    if (input.inspection.nonRootSubintentCount !== 0) {
+      return yield* new ExactPaymentSubintentValidationError({
+        code: 'NESTED_SUBINTENTS_UNSUPPORTED',
+      });
+    }
+
+    const payerAccount = payerAccountPattern.exec(
+      input.inspection.rootSubintent.intentCore.instructions,
+    )?.[1];
+
+    if (payerAccount === undefined) {
+      return yield* new ExactPaymentSubintentValidationError({
+        code: 'PAYER_ACCOUNT_NOT_FOUND',
+      });
+    }
+
+    const expectedManifest = paymentSubintentManifest({
+      requirements: input.requirements,
+      payerAccount,
+    });
+
+    if (
+      normalizeManifest(expectedManifest) !==
+      normalizeManifest(input.inspection.rootSubintent.intentCore.instructions)
+    ) {
+      return yield* new ExactPaymentSubintentValidationError({
+        code: 'NON_EXACT_PAYMENT_SUBINTENT',
+      });
+    }
+
+    return {
+      payerAccount,
+      subintentHash:
+        input.inspection.rootSubintentHash.id ??
+        input.inspection.rootSubintentHash.hex,
+    };
+  });

--- a/examples/x402/src/server.test.ts
+++ b/examples/x402/src/server.test.ts
@@ -1,0 +1,50 @@
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import type { PaymentRequirements } from './paymentRequirements';
+import { createX402Server } from './server';
+
+const requirements: PaymentRequirements = {
+  scheme: 'exact',
+  network: 'radix:mainnet',
+  resourceUrl: 'https://merchant.example/protected/reference.md',
+  payTo: 'account_rdx1282dj2he2pm0qdgrwn9nsymr8v3n2dr59u2rwzfq8t2vrlv9av74j4',
+  asset: 'resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd',
+  amount: '1.5',
+  maxTimeoutSeconds: 60,
+  extra: {
+    mode: 'sponsored',
+    notaryBadge: 'notary-badge',
+    intentDiscriminator: '123',
+  },
+};
+
+describe('x402 server', () => {
+  it('serves the Protected Markdown File after CommittedSuccess', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'x402-example-'));
+    const markdownPath = join(directory, 'reference.md');
+    await writeFile(markdownPath, '# Paid Reference\n\nSettled content.\n');
+
+    const app = createX402Server({
+      requirements,
+      markdownPath,
+      settlePayment: async () => ({ status: 'CommittedSuccess' }),
+    });
+
+    const response = await app.request('/protected/reference.md', {
+      headers: {
+        'X-PAYMENT': JSON.stringify({
+          x402Version: 2,
+          payload: { transaction: 'signed-partial-transaction-hex' },
+        }),
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('text/markdown');
+    expect(await response.text()).toBe(
+      '# Paid Reference\n\nSettled content.\n',
+    );
+  });
+});

--- a/examples/x402/src/server.test.ts
+++ b/examples/x402/src/server.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { Effect } from 'effect';
 import { describe, expect, it } from 'vitest';
 import type { PaymentRequirements } from './paymentRequirements';
 import { createX402Server } from './server';
@@ -29,7 +30,11 @@ describe('x402 server', () => {
     const app = createX402Server({
       requirements,
       markdownPath,
-      settlePayment: async () => ({ status: 'CommittedSuccess' }),
+      settlePayment: () =>
+        Effect.succeed({
+          status: 'CommittedSuccess',
+          subintentHash: 'subtxid_rdx1paid',
+        }),
     });
 
     const response = await app.request('/protected/reference.md', {

--- a/examples/x402/src/server.ts
+++ b/examples/x402/src/server.ts
@@ -1,0 +1,35 @@
+import { readFile } from 'node:fs/promises';
+import { Hono } from 'hono';
+import {
+  type X402PaymentMiddlewareOptions,
+  createX402PaymentMiddleware,
+} from './paymentMiddleware';
+import type { PaymentRequirements } from './paymentRequirements';
+
+export type X402ServerOptions = {
+  requirements: PaymentRequirements;
+  markdownPath: string;
+  settlePayment: X402PaymentMiddlewareOptions['settlePayment'];
+};
+
+export const createX402Server = ({
+  requirements,
+  markdownPath,
+  settlePayment,
+}: X402ServerOptions): Hono => {
+  const app = new Hono();
+
+  app.get(
+    '/protected/reference.md',
+    createX402PaymentMiddleware({ requirements, settlePayment }),
+    async (context) => {
+      const markdown = await readFile(markdownPath, 'utf8');
+
+      return context.body(markdown, 200, {
+        'content-type': 'text/markdown; charset=utf-8',
+      });
+    },
+  );
+
+  return app;
+};

--- a/examples/x402/src/server.ts
+++ b/examples/x402/src/server.ts
@@ -1,4 +1,5 @@
 import { readFile } from 'node:fs/promises';
+import { Data, Effect } from 'effect';
 import { Hono } from 'hono';
 import {
   type X402PaymentMiddlewareOptions,
@@ -12,6 +13,21 @@ export type X402ServerOptions = {
   settlePayment: X402PaymentMiddlewareOptions['settlePayment'];
 };
 
+export class ProtectedMarkdownReadError extends Data.TaggedError(
+  'ProtectedMarkdownReadError',
+)<{
+  path: string;
+  reason: unknown;
+}> {}
+
+const readProtectedMarkdown = Effect.fn('readProtectedMarkdown')(
+  (path: string) =>
+    Effect.tryPromise({
+      try: () => readFile(path, 'utf8'),
+      catch: (reason) => new ProtectedMarkdownReadError({ path, reason }),
+    }),
+);
+
 export const createX402Server = ({
   requirements,
   markdownPath,
@@ -22,13 +38,16 @@ export const createX402Server = ({
   app.get(
     '/protected/reference.md',
     createX402PaymentMiddleware({ requirements, settlePayment }),
-    async (context) => {
-      const markdown = await readFile(markdownPath, 'utf8');
-
-      return context.body(markdown, 200, {
-        'content-type': 'text/markdown; charset=utf-8',
-      });
-    },
+    (context) =>
+      Effect.runPromise(
+        readProtectedMarkdown(markdownPath).pipe(
+          Effect.map((markdown) =>
+            context.body(markdown, 200, {
+              'content-type': 'text/markdown; charset=utf-8',
+            }),
+          ),
+        ),
+      ),
   );
 
   return app;

--- a/examples/x402/src/serverMain.ts
+++ b/examples/x402/src/serverMain.ts
@@ -1,0 +1,47 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { serve } from '@hono/node-server';
+import { Effect } from 'effect';
+import {
+  type X402Config,
+  paymentRequirementsFromConfig,
+  validateX402Config,
+} from './config';
+import { createX402Server } from './server';
+import { createSponsoredSettlement } from './settlement';
+
+const configPath = process.env.X402_CONFIG ?? 'x402.config.template.json';
+const port = Number(process.env.PORT ?? 4020);
+
+const program = Effect.gen(function* () {
+  const rawConfig = yield* Effect.promise(() => readFile(configPath, 'utf8'));
+  const config = yield* validateX402Config(JSON.parse(rawConfig) as X402Config);
+  const resourceUrl = `${config.resourceBaseUrl}/protected/reference.md`;
+  const requirements = paymentRequirementsFromConfig({ config, resourceUrl });
+  const markdownPath = fileURLToPath(
+    new URL('../protected/reference.md', import.meta.url),
+  );
+  const settlePayment = createSponsoredSettlement({
+    settleValidatedPayment: async ({ payerAccount, subintentHash }) =>
+      process.env.X402_MOCK_SETTLEMENT === 'true'
+        ? {
+            status: 'CommittedSuccess',
+            payerAccount,
+            subintentHash,
+          }
+        : {
+            status: 'SettlementBackendNotConfigured',
+            subintentHash,
+          },
+  });
+  const app = createX402Server({
+    requirements,
+    markdownPath,
+    settlePayment,
+  });
+
+  serve({ fetch: app.fetch, port });
+  console.log(`x402 reference server listening on http://localhost:${port}`);
+});
+
+Effect.runPromise(program);

--- a/examples/x402/src/serverMain.ts
+++ b/examples/x402/src/serverMain.ts
@@ -3,9 +3,9 @@ import { fileURLToPath } from 'node:url';
 import { serve } from '@hono/node-server';
 import { Effect } from 'effect';
 import {
-  type X402Config,
+  ConfigParseError,
+  parseX402Config,
   paymentRequirementsFromConfig,
-  validateX402Config,
 } from './config';
 import { createX402Server } from './server';
 import { createSponsoredSettlement } from './settlement';
@@ -14,25 +14,30 @@ const configPath = process.env.X402_CONFIG ?? 'x402.config.template.json';
 const port = Number(process.env.PORT ?? 4020);
 
 const program = Effect.gen(function* () {
-  const rawConfig = yield* Effect.promise(() => readFile(configPath, 'utf8'));
-  const config = yield* validateX402Config(JSON.parse(rawConfig) as X402Config);
+  const rawConfig = yield* Effect.tryPromise({
+    try: () => readFile(configPath, 'utf8'),
+    catch: (reason) => new ConfigParseError({ reason }),
+  });
+  const config = yield* parseX402Config(rawConfig);
   const resourceUrl = `${config.resourceBaseUrl}/protected/reference.md`;
   const requirements = paymentRequirementsFromConfig({ config, resourceUrl });
   const markdownPath = fileURLToPath(
     new URL('../protected/reference.md', import.meta.url),
   );
   const settlePayment = createSponsoredSettlement({
-    settleValidatedPayment: async ({ payerAccount, subintentHash }) =>
-      process.env.X402_MOCK_SETTLEMENT === 'true'
-        ? {
-            status: 'CommittedSuccess',
-            payerAccount,
-            subintentHash,
-          }
-        : {
-            status: 'SettlementBackendNotConfigured',
-            subintentHash,
-          },
+    settleValidatedPayment: ({ payerAccount, subintentHash }) =>
+      Effect.succeed(
+        process.env.X402_MOCK_SETTLEMENT === 'true'
+          ? {
+              status: 'CommittedSuccess',
+              payerAccount,
+              subintentHash,
+            }
+          : {
+              status: 'SettlementBackendNotConfigured',
+              subintentHash,
+            },
+      ),
   });
   const app = createX402Server({
     requirements,
@@ -40,8 +45,12 @@ const program = Effect.gen(function* () {
     settlePayment,
   });
 
-  serve({ fetch: app.fetch, port });
-  console.log(`x402 reference server listening on http://localhost:${port}`);
+  yield* Effect.sync(() => {
+    serve({ fetch: app.fetch, port });
+  });
+  yield* Effect.logInfo(
+    `x402 reference server listening on http://localhost:${port}`,
+  );
 });
 
 Effect.runPromise(program);

--- a/examples/x402/src/settlement.test.ts
+++ b/examples/x402/src/settlement.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { paymentSubintentManifest } from './exactRadix';
+import type { PaymentRequirements } from './paymentRequirements';
+import { createSponsoredSettlement } from './settlement';
+
+const requirements: PaymentRequirements = {
+  scheme: 'exact',
+  network: 'radix:mainnet',
+  resourceUrl: 'https://merchant.example/protected/reference.md',
+  payTo: 'account_rdx1282dj2he2pm0qdgrwn9nsymr8v3n2dr59u2rwzfq8t2vrlv9av74j4',
+  asset: 'resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd',
+  amount: '1.5',
+  maxTimeoutSeconds: 60,
+  extra: {
+    mode: 'sponsored',
+    notaryBadge: 'notary-badge',
+    intentDiscriminator: '123',
+  },
+};
+
+describe('Sponsored Subintent settlement', () => {
+  it('inspects, validates, settles, and returns CommittedSuccess', async () => {
+    const settlePayment = createSponsoredSettlement({
+      inspectSignedPartialTransaction: async () => ({
+        rootSubintentHash: { id: 'subtxid_rdx1paid', hex: 'aa' },
+        nonRootSubintentCount: 0,
+        rootSubintentSignatures: [
+          {
+            curve: 'Ed25519',
+            signature: '22'.repeat(64),
+            publicKey: '11'.repeat(32),
+          },
+        ],
+        rootSubintent: {
+          intentCore: {
+            header: {
+              networkId: 1,
+              intentDiscriminator: 123,
+            },
+            instructions: paymentSubintentManifest({
+              requirements,
+              payerAccount:
+                'account_rdx129a9wuey40lducsne6r8e5q7xmt07068gcede0x0nrwtsnehpkf6zh',
+            }),
+          },
+        },
+      }),
+      settleValidatedPayment: async ({ payerAccount, subintentHash }) => ({
+        status: 'CommittedSuccess',
+        payerAccount,
+        subintentHash,
+      }),
+    });
+
+    await expect(
+      settlePayment({
+        requirements,
+        resourceUrl: requirements.resourceUrl,
+        signedPartialTransactionHex: '4d220504',
+      }),
+    ).resolves.toEqual({
+      status: 'CommittedSuccess',
+      payerAccount:
+        'account_rdx129a9wuey40lducsne6r8e5q7xmt07068gcede0x0nrwtsnehpkf6zh',
+      subintentHash: 'subtxid_rdx1paid',
+    });
+  });
+});

--- a/examples/x402/src/settlement.test.ts
+++ b/examples/x402/src/settlement.test.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 import { describe, expect, it } from 'vitest';
 import { paymentSubintentManifest } from './exactRadix';
 import type { PaymentRequirements } from './paymentRequirements';
@@ -21,43 +22,47 @@ const requirements: PaymentRequirements = {
 describe('Sponsored Subintent settlement', () => {
   it('inspects, validates, settles, and returns CommittedSuccess', async () => {
     const settlePayment = createSponsoredSettlement({
-      inspectSignedPartialTransaction: async () => ({
-        rootSubintentHash: { id: 'subtxid_rdx1paid', hex: 'aa' },
-        nonRootSubintentCount: 0,
-        rootSubintentSignatures: [
-          {
-            curve: 'Ed25519',
-            signature: '22'.repeat(64),
-            publicKey: '11'.repeat(32),
-          },
-        ],
-        rootSubintent: {
-          intentCore: {
-            header: {
-              networkId: 1,
-              intentDiscriminator: 123,
+      inspectSignedPartialTransaction: () =>
+        Effect.succeed({
+          rootSubintentHash: { id: 'subtxid_rdx1paid', hex: 'aa' },
+          nonRootSubintentCount: 0,
+          rootSubintentSignatures: [
+            {
+              curve: 'Ed25519',
+              signature: '22'.repeat(64),
+              publicKey: '11'.repeat(32),
             },
-            instructions: paymentSubintentManifest({
-              requirements,
-              payerAccount:
-                'account_rdx129a9wuey40lducsne6r8e5q7xmt07068gcede0x0nrwtsnehpkf6zh',
-            }),
+          ],
+          rootSubintent: {
+            intentCore: {
+              header: {
+                networkId: 1,
+                intentDiscriminator: 123,
+              },
+              instructions: paymentSubintentManifest({
+                requirements,
+                payerAccount:
+                  'account_rdx129a9wuey40lducsne6r8e5q7xmt07068gcede0x0nrwtsnehpkf6zh',
+              }),
+            },
           },
-        },
-      }),
-      settleValidatedPayment: async ({ payerAccount, subintentHash }) => ({
-        status: 'CommittedSuccess',
-        payerAccount,
-        subintentHash,
-      }),
+        }),
+      settleValidatedPayment: ({ payerAccount, subintentHash }) =>
+        Effect.succeed({
+          status: 'CommittedSuccess',
+          payerAccount,
+          subintentHash,
+        }),
     });
 
     await expect(
-      settlePayment({
-        requirements,
-        resourceUrl: requirements.resourceUrl,
-        signedPartialTransactionHex: '4d220504',
-      }),
+      Effect.runPromise(
+        settlePayment({
+          requirements,
+          resourceUrl: requirements.resourceUrl,
+          signedPartialTransactionHex: '4d220504',
+        }),
+      ),
     ).resolves.toEqual({
       status: 'CommittedSuccess',
       payerAccount:

--- a/examples/x402/src/settlement.ts
+++ b/examples/x402/src/settlement.ts
@@ -1,0 +1,61 @@
+import { inspectSignedPartialTransaction as inspectWithTxTool } from '@radix-effects/tx-tool';
+import { Effect } from 'effect';
+import type { PaymentRequirements } from './paymentRequirements';
+import {
+  type PaymentSubintentInspection,
+  validateExactPaymentSubintent,
+} from './paymentValidation';
+
+export type SettlementInput = {
+  signedPartialTransactionHex: string;
+  requirements: PaymentRequirements;
+  resourceUrl: string;
+};
+
+export type CommittedSettlement = {
+  status: 'CommittedSuccess';
+  payerAccount: string;
+  subintentHash: string;
+};
+
+export type SponsoredSettlementOptions = {
+  inspectSignedPartialTransaction?: (input: {
+    signedPartialTransactionHex: string;
+    networkId: 1;
+  }) => Promise<PaymentSubintentInspection>;
+  settleValidatedPayment: (input: {
+    signedPartialTransactionHex: string;
+    requirements: PaymentRequirements;
+    resourceUrl: string;
+    payerAccount: string;
+    subintentHash: string;
+  }) => Promise<
+    CommittedSettlement | { status: string; subintentHash?: string }
+  >;
+};
+
+export const createSponsoredSettlement =
+  ({
+    inspectSignedPartialTransaction = inspectWithTxTool,
+    settleValidatedPayment,
+  }: SponsoredSettlementOptions) =>
+  async (input: SettlementInput) => {
+    const inspection = await inspectSignedPartialTransaction({
+      signedPartialTransactionHex: input.signedPartialTransactionHex,
+      networkId: 1,
+    });
+    const validation = await Effect.runPromise(
+      validateExactPaymentSubintent({
+        inspection,
+        requirements: input.requirements,
+      }),
+    );
+
+    return settleValidatedPayment({
+      signedPartialTransactionHex: input.signedPartialTransactionHex,
+      requirements: input.requirements,
+      resourceUrl: input.resourceUrl,
+      payerAccount: validation.payerAccount,
+      subintentHash: validation.subintentHash,
+    });
+  };

--- a/examples/x402/src/settlement.ts
+++ b/examples/x402/src/settlement.ts
@@ -1,5 +1,5 @@
 import { inspectSignedPartialTransaction as inspectWithTxTool } from '@radix-effects/tx-tool';
-import { Effect } from 'effect';
+import { Data, Effect } from 'effect';
 import type { PaymentRequirements } from './paymentRequirements';
 import {
   type PaymentSubintentInspection,
@@ -18,44 +18,57 @@ export type CommittedSettlement = {
   subintentHash: string;
 };
 
+export class SignedPartialTransactionInspectionError extends Data.TaggedError(
+  'SignedPartialTransactionInspectionError',
+)<{
+  reason: unknown;
+}> {}
+
 export type SponsoredSettlementOptions = {
   inspectSignedPartialTransaction?: (input: {
     signedPartialTransactionHex: string;
     networkId: 1;
-  }) => Promise<PaymentSubintentInspection>;
+  }) => Effect.Effect<PaymentSubintentInspection, unknown>;
   settleValidatedPayment: (input: {
     signedPartialTransactionHex: string;
     requirements: PaymentRequirements;
     resourceUrl: string;
     payerAccount: string;
     subintentHash: string;
-  }) => Promise<
-    CommittedSettlement | { status: string; subintentHash?: string }
+  }) => Effect.Effect<
+    CommittedSettlement | { status: string; subintentHash?: string },
+    unknown
   >;
 };
 
-export const createSponsoredSettlement =
-  ({
-    inspectSignedPartialTransaction = inspectWithTxTool,
-    settleValidatedPayment,
-  }: SponsoredSettlementOptions) =>
-  async (input: SettlementInput) => {
-    const inspection = await inspectSignedPartialTransaction({
+const inspectSignedPartialTransactionWithTxTool = (input: {
+  signedPartialTransactionHex: string;
+  networkId: 1;
+}) =>
+  Effect.tryPromise({
+    try: () => inspectWithTxTool(input),
+    catch: (reason) => new SignedPartialTransactionInspectionError({ reason }),
+  });
+
+export const createSponsoredSettlement = ({
+  inspectSignedPartialTransaction = inspectSignedPartialTransactionWithTxTool,
+  settleValidatedPayment,
+}: SponsoredSettlementOptions) =>
+  Effect.fn('sponsoredSettlement')(function* (input: SettlementInput) {
+    const inspection = yield* inspectSignedPartialTransaction({
       signedPartialTransactionHex: input.signedPartialTransactionHex,
       networkId: 1,
     });
-    const validation = await Effect.runPromise(
-      validateExactPaymentSubintent({
-        inspection,
-        requirements: input.requirements,
-      }),
-    );
+    const validation = yield* validateExactPaymentSubintent({
+      inspection,
+      requirements: input.requirements,
+    });
 
-    return settleValidatedPayment({
+    return yield* settleValidatedPayment({
       signedPartialTransactionHex: input.signedPartialTransactionHex,
       requirements: input.requirements,
       resourceUrl: input.resourceUrl,
       payerAccount: validation.payerAccount,
       subintentHash: validation.subintentHash,
     });
-  };
+  });

--- a/examples/x402/src/settlementCache.test.ts
+++ b/examples/x402/src/settlementCache.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import type { PaymentRequirements } from './paymentRequirements';
+import { settlementCacheKey } from './settlementCache';
+
+const requirements: PaymentRequirements = {
+  scheme: 'exact',
+  network: 'radix:mainnet',
+  resourceUrl: 'https://merchant.example/protected/reference.md',
+  payTo: 'account_rdx1282dj2he2pm0qdgrwn9nsymr8v3n2dr59u2rwzfq8t2vrlv9av74j4',
+  asset: 'resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd',
+  amount: '1.5',
+  maxTimeoutSeconds: 60,
+  extra: {
+    mode: 'sponsored',
+    notaryBadge: 'notary-badge',
+    intentDiscriminator: '123',
+  },
+};
+
+describe('Settlement Cache Key', () => {
+  it('is scoped to the subintent hash, payment requirements, and resource URL', () => {
+    const key = settlementCacheKey({
+      subintentHash: 'subtxid_A',
+      requirements,
+      resourceUrl: requirements.resourceUrl,
+    });
+
+    expect(
+      settlementCacheKey({
+        subintentHash: 'subtxid_B',
+        requirements,
+        resourceUrl: requirements.resourceUrl,
+      }),
+    ).not.toBe(key);
+
+    expect(
+      settlementCacheKey({
+        subintentHash: 'subtxid_A',
+        requirements: { ...requirements, amount: '2' },
+        resourceUrl: requirements.resourceUrl,
+      }),
+    ).not.toBe(key);
+
+    expect(
+      settlementCacheKey({
+        subintentHash: 'subtxid_A',
+        requirements,
+        resourceUrl: 'https://merchant.example/protected/other.md',
+      }),
+    ).not.toBe(key);
+  });
+});

--- a/examples/x402/src/settlementCache.ts
+++ b/examples/x402/src/settlementCache.ts
@@ -1,0 +1,26 @@
+import { createHash } from 'node:crypto';
+import {
+  type PaymentRequirements,
+  paymentRequirementsHash,
+} from './paymentRequirements';
+
+export type SettlementCacheKeyInput = {
+  subintentHash: string;
+  requirements: PaymentRequirements;
+  resourceUrl: string;
+};
+
+export const settlementCacheKey = ({
+  subintentHash,
+  requirements,
+  resourceUrl,
+}: SettlementCacheKeyInput): string =>
+  createHash('sha256')
+    .update(
+      JSON.stringify([
+        ['subintentHash', subintentHash],
+        ['paymentRequirementsHash', paymentRequirementsHash(requirements)],
+        ['resourceUrl', resourceUrl],
+      ]),
+    )
+    .digest('hex');

--- a/examples/x402/tsconfig.json
+++ b/examples/x402/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node", "vitest"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/examples/x402/vitest.config.ts
+++ b/examples/x402/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/examples/x402/x402.config.template.json
+++ b/examples/x402/x402.config.template.json
@@ -1,0 +1,12 @@
+{
+  "networkId": 1,
+  "gatewayBaseUrl": "<MAINNET_GATEWAY_BASE_URL>",
+  "resourceBaseUrl": "<RESOURCE_BASE_URL>",
+  "feePayerAccount": "<FEE_PAYER_ACCOUNT>",
+  "payTo": "<PAY_TO_ACCOUNT>",
+  "facilitatorNotaryBadge": "<FACILITATOR_NOTARY_BADGE>",
+  "asset": "<PAYMENT_ASSET>",
+  "amount": "1",
+  "maxTimeoutSeconds": 60,
+  "intentDiscriminator": "<INTENT_DISCRIMINATOR>"
+}

--- a/packages/cli/CONTEXT.md
+++ b/packages/cli/CONTEXT.md
@@ -256,6 +256,38 @@ _Avoid_: Array position, duplicate subintent name
 The rdx preparation step that composes a provided root RTM manifest with provided direct child subintent manifests into a Transaction Manifest V2 transaction.
 _Avoid_: Business intent inference, placeholder-driven root manifest
 
+**Subintent Signing Preparation**:
+The rdx step that builds or reads a standalone Subintent and emits the Subintent hash as a signing request.
+_Avoid_: Full transaction preparation, facilitator root preparation
+
+**Subintent Header File**:
+A typed workflow file passed with `--header` that supplies standalone Subintent header settings and optional message settings for Subintent Signing Preparation.
+_Avoid_: Core file, settings file, manifest-only subintent input
+
+**Subintent Preview-before-Signing**:
+A signer-safety preview where rdx uses a temporary root transaction manifest to execute a standalone Subintent before emitting a signing request.
+_Avoid_: Naked Subintent preview, mandatory settlement preview
+
+**Subintent Preview Root Manifest**:
+A Transaction Manifest V2 root manifest passed to standalone Subintent preparation with `--root-manifest` and used only for Subintent Preview-before-Signing.
+_Avoid_: Preview parent file, x402-only preview template, implicit root manifest
+
+**Subintent Hash Placeholder**:
+The literal `<subintentHash>` token in a Subintent Preview Root Manifest that rdx replaces with the computed Subintent hash for preview.
+_Avoid_: Precomputed preview child hash, implicit placeholder
+
+**Prepared Subintent File**:
+A JSON file produced by Subintent Signing Preparation that records the Subintent hash and paths to copied Subintent artifacts needed for signing and build.
+_Avoid_: Prepared transaction file, stdout-only Subintent hash
+
+**Signed Partial Transaction Build**:
+The rdx step that builds a signed partial transaction from a prepared Subintent and out-of-band signature.
+_Avoid_: Notarized transaction assembly, root transaction submission
+
+**Signed Partial Transaction File**:
+A hex artifact written by `rdx subintent build` containing the signed partial transaction payload.
+_Avoid_: Stdout-only signed payload, notarized transaction file
+
 **Subintent Order**:
 The deterministic ordered list of subintent IDs used to map keyed rdx workflow files to Radix toolkit subintent arrays.
 _Avoid_: Implicit object iteration, index-only subintent identity
@@ -398,6 +430,18 @@ _Avoid_: Signature mutation during notarization, raw signature archive
 - v1 **CLI Public Key** and **CLI Signature** values support Ed25519 only; other curves are deferred.
 - Unknown **CLI Public Key** values in generated templates use `{ "curve": "Ed25519", "hex": "<replace-with-ed25519-public-key-hex>" }` and are rejected if submitted unchanged.
 - v1 supports root transactions with direct child **Subintents** only; nested subintent graphs are out of scope.
+- Standalone Subintent workflows use **Subintent Signing Preparation** followed by **Signed Partial Transaction Build**.
+- **Subintent Signing Preparation** reads the Subintent manifest plus a **Subintent Header File** because the signed Subintent includes both header and message.
+- **Subintent Signing Preparation** performs **Subintent Preview-before-Signing** when a **Subintent Preview Root Manifest** is supplied.
+- A **Subintent Preview Root Manifest** must contain exactly one **Subintent Hash Placeholder**.
+- **Subintent Preview-before-Signing** is best-effort and may be skipped when the caller does not have a suitable preview root manifest.
+- Standalone Subintent preparation may bypass preview only through an explicit no-preview option.
+- `rdx subintent prepare` requires either `--root-manifest` or an explicit no-preview option.
+- **Subintent Signing Preparation** writes a **Prepared Subintent File** and copied Subintent artifacts.
+- Standalone Subintent commands belong under the generic `rdx subintent` surface rather than x402-specific command names.
+- **Signed Partial Transaction Build** is exposed as `rdx subintent build`.
+- **Signed Partial Transaction Build** writes a **Signed Partial Transaction File** and also prints the hex payload in its JSON command result.
+- v1 standalone Subintent workflows do not support nested child Subintents.
 - Root RTM manifests are provided by the caller and may contain normal root instructions with or without subintent yields.
 - **Subintent Assembly** injects required `USE_CHILD` declarations for provided subintents and leaves the caller's root instructions otherwise unchanged.
 - **Subintent Assembly** strictly validates that each provided **Subintent ID** is referenced by the root manifest and that each root `YIELD_TO_CHILD` has a provided subintent.
@@ -605,6 +649,42 @@ _Avoid_: Signature mutation during notarization, raw signature archive
 
 > **Dev:** "Should v1 support nested subintent graphs?"
 > **Domain expert:** "No — v1 supports direct child **Subintents** only."
+
+> **Dev:** "Should standalone Subintent signing commands live under `rdx x402`?"
+> **Domain expert:** "No — use generic `rdx subintent` commands because **Subintent Signing Preparation** and **Signed Partial Transaction Build** are not x402-specific."
+
+> **Dev:** "Can standalone Subintent preparation take only a manifest and infer the rest?"
+> **Domain expert:** "No — require a **Subintent Header File** with `--header` so header and message settings are explicit."
+
+> **Dev:** "Can rdx preview a standalone Subintent without a parent?"
+> **Domain expert:** "No — use **Subintent Preview-before-Signing** with a temporary parent preview transaction."
+
+> **Dev:** "Should rdx hard-code the preview root manifest for standalone Subintents?"
+> **Domain expert:** "No — accept a **Subintent Preview Root Manifest** with `--root-manifest` so each use case can provide a realistic root shape."
+
+> **Dev:** "Should agents precompute the child hash before writing the preview root manifest?"
+> **Domain expert:** "No — use a **Subintent Hash Placeholder** and let rdx replace it after hashing the Subintent."
+
+> **Dev:** "Can standalone Subintent preparation proceed without a preview root manifest?"
+> **Domain expert:** "Yes — **Subintent Preview-before-Signing** is best-effort, but skipping it must be explicit."
+
+> **Dev:** "Can `rdx subintent prepare` omit both `--root-manifest` and no-preview?"
+> **Domain expert:** "No — require either `--root-manifest` or an explicit no-preview option."
+
+> **Dev:** "Can standalone Subintent preparation silently skip preview?"
+> **Domain expert:** "No — preview is the default; skipping requires an explicit no-preview option."
+
+> **Dev:** "Can `rdx subintent prepare` only print the Subintent hash to stdout?"
+> **Domain expert:** "No — write a **Prepared Subintent File** so `rdx subintent build` has a stable artifact input."
+
+> **Dev:** "Should the signed partial transaction command be called `finalize` or `assemble`?"
+> **Domain expert:** "No — use `rdx subintent build`; the `subintent` command context already scopes what is being built."
+
+> **Dev:** "Should `rdx subintent build` only write the signed partial transaction to a file?"
+> **Domain expert:** "No — write a **Signed Partial Transaction File** and include the hex in the command result for agent handoff."
+
+> **Dev:** "Should v1 standalone Subintent workflows support nested child Subintents?"
+> **Domain expert:** "No — v1 standalone Subintent workflows build one root Subintent with no children."
 
 > **Dev:** "Should users precompute child intent IDs before writing the root manifest?"
 > **Domain expert:** "No — provide root and child manifests separately and let **Subintent Assembly** inject `USE_CHILD` declarations."

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -370,6 +370,86 @@ describe('rdx command interface', () => {
     expect(prepared.subintentOrder).toEqual(['child_one']);
   });
 
+  it('prepares and builds standalone subintent artifacts', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'rdx-cli-subintent-'));
+    const manifestPath = join(cwd, 'payment.rtm');
+    const headerPath = join(cwd, 'subintent-header.json');
+    await writeFile(manifestPath, 'YIELD_TO_PARENT;', 'utf8');
+    await writeFile(
+      headerPath,
+      JSON.stringify({
+        type: 'subintentHeader',
+        version: 1,
+        header: {
+          networkId: 1,
+          startEpochInclusive: 1,
+          endEpochExclusive: 10,
+          intentDiscriminator: 123,
+        },
+      }),
+      'utf8',
+    );
+
+    const prepareResult = await runRdx({
+      argv: [
+        'subintent',
+        'prepare',
+        '--manifest',
+        manifestPath,
+        '--header',
+        headerPath,
+        '--no-preview',
+      ],
+      cwd,
+    });
+
+    expect(prepareResult.exitCode).toBe(0);
+    const preparedOutput = JSON.parse(prepareResult.stdout);
+    expect(preparedOutput).toMatchObject({
+      type: 'commandResult',
+      command: 'subintent prepare',
+    });
+
+    const signaturePath = join(cwd, 'signature.json');
+    await writeFile(
+      signaturePath,
+      JSON.stringify({
+        type: 'signatureFile',
+        version: 1,
+        transactionId: preparedOutput.subintentHash.id,
+        signatures: [
+          {
+            scope: { kind: 'subintent', subintentId: 'root' },
+            account: null,
+            hash: preparedOutput.subintentHash,
+            publicKey: { curve: 'Ed25519', hex: '1'.repeat(64) },
+            signature: { curve: 'Ed25519', hex: '2'.repeat(128) },
+          },
+        ],
+      }),
+      'utf8',
+    );
+
+    const buildResult = await runRdx({
+      argv: [
+        'subintent',
+        'build',
+        '--prepared',
+        preparedOutput.preparedPath,
+        '--signature',
+        signaturePath,
+      ],
+      cwd,
+    });
+
+    expect(buildResult.exitCode).toBe(0);
+    expect(JSON.parse(buildResult.stdout)).toMatchObject({
+      type: 'commandResult',
+      command: 'subintent build',
+      signedPartialTransactionHex: expect.stringMatching(/^[0-9a-f]+$/),
+    });
+  });
+
   it('creates notary signing artifacts from complete transaction artifacts', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'rdx-cli-notarize-'));
     await writeCompleteNotarizeArtifact({ cwd, transactionId: 'txid_1' });

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -47,6 +47,11 @@ describe('rdx command interface', () => {
     expect(result.stdout).toContain(
       '`rdx` never stores, accepts, or derives private keys',
     );
+    expect(result.stdout).toContain('## Standalone Subintent Lifecycle');
+    expect(result.stdout).toContain(
+      'rdx subintent prepare --manifest <subintent.rtm> --header <header.json> --root-manifest <root.rtm>',
+    );
+    expect(result.stdout).toContain('signedPartialTransactionHex');
     expect(() => JSON.parse(result.stdout)).toThrow();
   });
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,3 +1,4 @@
+import { dirname, join } from 'node:path';
 import { Args, Command, Options } from '@effect/cli';
 import { Console, Effect, Option, Schema } from 'effect';
 import {
@@ -47,6 +48,12 @@ import {
   listTransactionArtifactsWithNetworkStatus,
   queryTransactionStatus,
 } from './status';
+import {
+  type BuildSignedPartialTransactionResult,
+  type PrepareSubintentResult,
+  buildSignedPartialTransaction,
+  prepareSubintentArtifacts,
+} from './subintent';
 import {
   type SubmitTransactionResult,
   gatewaySubmitNotarizedTransaction,
@@ -189,6 +196,47 @@ export const renderPrepare = (
 
   if (format === 'text') {
     return result.preparedPath;
+  }
+
+  return renderJson(commandResult);
+};
+
+export const renderSubintentPrepare = (
+  format: OutputFormat,
+  result: PrepareSubintentResult,
+) => {
+  const commandResult = {
+    type: 'commandResult',
+    command: 'subintent prepare',
+    subintentHash: result.subintentHash,
+    artifactPath: result.artifactPath,
+    preparedPath: result.preparedPath,
+    signingRequestPath: result.signingRequestPath,
+    signatureTemplatePath: result.signatureTemplatePath,
+  };
+
+  if (format === 'text') {
+    return result.preparedPath;
+  }
+
+  return renderJson(commandResult);
+};
+
+export const renderSubintentBuild = (
+  format: OutputFormat,
+  result: BuildSignedPartialTransactionResult,
+) => {
+  const commandResult = {
+    type: 'commandResult',
+    command: 'subintent build',
+    subintentHash: result.subintentHash,
+    artifactPath: result.artifactPath,
+    signedPartialTransactionPath: result.signedPartialTransactionPath,
+    signedPartialTransactionHex: result.signedPartialTransactionHex,
+  };
+
+  if (format === 'text') {
+    return result.signedPartialTransactionHex;
   }
 
   return renderJson(commandResult);
@@ -359,8 +407,33 @@ const txCommand = Command.make('tx').pipe(
   Command.withDescription('Work with transaction artifacts'),
 );
 
+const subintentCommand = Command.make('subintent').pipe(
+  Command.withDescription('Prepare and build standalone Subintent artifacts'),
+);
+
 const manifestOption = Options.file('manifest', { exists: 'yes' }).pipe(
   Options.withDescription('Root Transaction Manifest V2 file'),
+);
+const subintentManifestOption = Options.file('manifest', {
+  exists: 'yes',
+}).pipe(Options.withDescription('Subintent Manifest V2 file'));
+const subintentHeaderOption = Options.file('header', { exists: 'yes' }).pipe(
+  Options.withDescription('Subintent header workflow file'),
+);
+const rootManifestOption = Options.file('root-manifest', {
+  exists: 'yes',
+}).pipe(
+  Options.optional,
+  Options.withDescription('Temporary root manifest for Subintent preview'),
+);
+const noPreviewOption = Options.boolean('no-preview').pipe(
+  Options.withDescription('Explicitly skip Subintent preview'),
+);
+const preparedSubintentOption = Options.file('prepared', {
+  exists: 'yes',
+}).pipe(Options.withDescription('Prepared Subintent workflow file'));
+const signatureOption = Options.file('signature', { exists: 'yes' }).pipe(
+  Options.withDescription('Signature file for the prepared Subintent'),
 );
 const notaryFileOption = Options.file('notary-file', { exists: 'yes' }).pipe(
   Options.optional,
@@ -428,6 +501,50 @@ const txPrepareCommand = Command.make(
       yield* Console.log(renderPrepare(format, result));
     }),
 ).pipe(Command.withDescription('Prepare transaction artifacts'));
+
+const subintentArtifactRoot = (
+  config: Pick<ResolvedRdxConfig, 'artifactRoot'>,
+) => join(dirname(config.artifactRoot), 'subintents');
+
+const subintentPrepareCommand = Command.make(
+  'prepare',
+  {
+    manifest: subintentManifestOption,
+    header: subintentHeaderOption,
+    rootManifest: rootManifestOption,
+    noPreview: noPreviewOption,
+  },
+  ({ header, manifest, noPreview, rootManifest }) =>
+    Effect.gen(function* () {
+      const { format } = yield* rdxCommand;
+      const config = yield* resolveRdxConfig({ cwd: process.cwd() });
+      const result = yield* prepareSubintentArtifacts({
+        artifactRoot: subintentArtifactRoot(config),
+        manifestPath: manifest,
+        headerPath: header,
+        rootManifestPath: Option.getOrUndefined(rootManifest),
+        noPreview,
+      });
+      yield* Console.log(renderSubintentPrepare(format, result));
+    }),
+).pipe(Command.withDescription('Prepare a standalone Subintent for signing'));
+
+const subintentBuildCommand = Command.make(
+  'build',
+  {
+    prepared: preparedSubintentOption,
+    signature: signatureOption,
+  },
+  ({ prepared, signature }) =>
+    Effect.gen(function* () {
+      const { format } = yield* rdxCommand;
+      const result = yield* buildSignedPartialTransaction({
+        preparedPath: prepared,
+        signaturePath: signature,
+      });
+      yield* Console.log(renderSubintentBuild(format, result));
+    }),
+).pipe(Command.withDescription('Build a signed partial transaction'));
 
 const patternOption = Options.text('pattern').pipe(Options.optional);
 const regexOption = Options.text('regex').pipe(Options.optional);
@@ -641,6 +758,9 @@ export const command = rdxCommand.pipe(
     configCommand.pipe(Command.withSubcommands([configShowCommand])),
     llmCommand,
     templateCommand.pipe(Command.withSubcommands([templatePrintCommand])),
+    subintentCommand.pipe(
+      Command.withSubcommands([subintentPrepareCommand, subintentBuildCommand]),
+    ),
     txCommand.pipe(
       Command.withSubcommands([
         txAddSignaturesCommand,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,3 +1,4 @@
+import { dirname, join } from 'node:path';
 import { AccountAddress, TransactionId } from '@radix-effects/shared';
 import { Data, Effect, Schema } from 'effect';
 import {
@@ -22,6 +23,8 @@ import {
   renderLlmGuide,
   renderNotarize,
   renderPrepare,
+  renderSubintentBuild,
+  renderSubintentPrepare,
   renderSubmit,
   renderTemplate,
   renderTxList,
@@ -46,6 +49,10 @@ import {
   queryTransactionStatus,
 } from './status';
 import {
+  buildSignedPartialTransaction,
+  prepareSubintentArtifacts,
+} from './subintent';
+import {
   gatewaySubmitNotarizedTransaction,
   submitTransactionArtifact,
 } from './submit';
@@ -66,6 +73,7 @@ export * from './signingRequests';
 export * from './status';
 export * from './submit';
 export * from './subintentAssembly';
+export * from './subintent';
 export * from './templates';
 
 export type RdxResult = {
@@ -188,6 +196,16 @@ type ParsedRdxCommand = Data.TaggedEnum<{
   };
   TxStatus: { transactionId: TransactionId; readOnly: boolean };
   TxHistory: { accountAddress: AccountAddress; limit: number };
+  SubintentPrepare: {
+    manifestPath?: string;
+    headerPath?: string;
+    rootManifestPath?: string;
+    noPreview: boolean;
+  };
+  SubintentBuild: {
+    preparedPath?: string;
+    signaturePath?: string;
+  };
   TemplatePrint: { kind: TemplateKind };
   Unknown: { command: string };
 }>;
@@ -304,6 +322,22 @@ const parseRdxCommand = (
       return RdxCommand.TxHistory({
         accountAddress: AccountAddress.make(argv[2]),
         limit: Number(takeOption(argv, '--limit') ?? 10),
+      });
+    }
+
+    if (argv[0] === 'subintent' && argv[1] === 'prepare') {
+      return RdxCommand.SubintentPrepare({
+        manifestPath: takeOption(argv, '--manifest'),
+        headerPath: takeOption(argv, '--header'),
+        rootManifestPath: takeOption(argv, '--root-manifest'),
+        noPreview: argv.includes('--no-preview'),
+      });
+    }
+
+    if (argv[0] === 'subintent' && argv[1] === 'build') {
+      return RdxCommand.SubintentBuild({
+        preparedPath: takeOption(argv, '--prepared'),
+        signaturePath: takeOption(argv, '--signature'),
       });
     }
 
@@ -566,6 +600,71 @@ export const runRdxEffect = (input: RunRdxInput): Effect.Effect<RdxResult> =>
           return {
             exitCode: 0,
             stdout: `${renderCommandResult(format, result)}\n`,
+            stderr: '',
+          };
+        }),
+      SubintentPrepare: ({
+        headerPath,
+        manifestPath,
+        noPreview,
+        rootManifestPath,
+      }) =>
+        Effect.gen(function* () {
+          if (!manifestPath) {
+            return structuredError({
+              code: 'MISSING_ARGUMENT',
+              message: 'subintent prepare requires --manifest',
+              exitCode: 64,
+            });
+          }
+          if (!headerPath) {
+            return structuredError({
+              code: 'MISSING_ARGUMENT',
+              message: 'subintent prepare requires --header',
+              exitCode: 64,
+            });
+          }
+
+          const config = yield* resolveRdxConfig({ cwd: input.cwd });
+          const result = yield* prepareSubintentArtifacts({
+            artifactRoot: join(dirname(config.artifactRoot), 'subintents'),
+            manifestPath,
+            headerPath,
+            rootManifestPath,
+            noPreview,
+          });
+
+          return {
+            exitCode: 0,
+            stdout: `${renderSubintentPrepare(format, result)}\n`,
+            stderr: '',
+          };
+        }),
+      SubintentBuild: ({ preparedPath, signaturePath }) =>
+        Effect.gen(function* () {
+          if (!preparedPath) {
+            return structuredError({
+              code: 'MISSING_ARGUMENT',
+              message: 'subintent build requires --prepared',
+              exitCode: 64,
+            });
+          }
+          if (!signaturePath) {
+            return structuredError({
+              code: 'MISSING_ARGUMENT',
+              message: 'subintent build requires --signature',
+              exitCode: 64,
+            });
+          }
+
+          const result = yield* buildSignedPartialTransaction({
+            preparedPath,
+            signaturePath,
+          });
+
+          return {
+            exitCode: 0,
+            stdout: `${renderSubintentBuild(format, result)}\n`,
             stderr: '',
           };
         }),

--- a/packages/cli/src/llm.ts
+++ b/packages/cli/src/llm.ts
@@ -16,6 +16,10 @@ Use \`rdx\` to prepare, inspect, sign-orchestrate, notarize, submit, and track R
 - Do not rerun \`tx prepare\` expecting overwrite. Existing transaction artifact directories are protected.
 - Do not submit until intent, subintent, notary-signatory, and notary signatures required by the artifacts are complete.
 - Use \`tx path\` and \`tx list\` before manually scanning artifact directories.
+- Use \`rdx subintent prepare/build\` for standalone Subintent signing flows where another system will wrap the signed partial transaction in a root transaction.
+- Standalone Subintent preparation requires \`--header\` and either \`--root-manifest\` for preview or explicit \`--no-preview\` as a last resort.
+- A Subintent manifest intended for a parent transaction should usually end with \`YIELD_TO_PARENT;\`.
+- A Subintent preview root manifest must contain the literal \`<subintentHash>\` placeholder exactly once.
 
 ## Discover Live Inputs
 
@@ -27,6 +31,8 @@ rdx template print signature-template
 rdx template print signature-file
 rdx --help
 rdx tx prepare --help
+rdx subintent prepare --help
+rdx subintent build --help
 \`\`\`
 
 Use template output for workflow file shapes. Do not rely on copied config schemas; use \`rdx config show\` for resolved configuration.
@@ -88,6 +94,59 @@ rdx tx submit txid_example
 
 Subintent IDs in \`subintents.json\` are also Radix \`NamedIntent\` values referenced by root \`YIELD_TO_CHILD\` instructions. v1 supports root plus direct child subintents only. Multiple parties can return signatures asynchronously; repeat \`tx add-signatures\` until local completeness allows \`tx notarize\` and later \`tx submit\`.
 
+## Standalone Subintent Lifecycle
+
+Use \`rdx subintent\` when the agent only needs to create and sign a Subintent, then send the resulting signed partial transaction to another service. This is the right shape for HTTP payment flows such as x402, where a server receives the signed partial transaction and builds the sponsored root transaction.
+
+1. Prepare a Subintent manifest and Subintent header file.
+2. Prefer to supply a preview root manifest with \`--root-manifest\`; use \`--no-preview\` only when the parent/root context is unavailable.
+3. Run \`rdx subintent prepare --manifest <subintent.rtm> --header <header.json> --root-manifest <root.rtm>\`.
+4. Inspect \`prepared-subintent.json\`, \`signing-request.json\`, \`signature-template.json\`, and the command JSON output.
+5. Sign only the \`signing-request.json\` \`hash.hex\` outside \`rdx\`.
+6. Fill a signature file or the generated signature template.
+7. Run \`rdx subintent build --prepared <prepared-subintent.json> --signature <signature.json>\`.
+8. Send \`signedPartialTransactionHex\` to the external parent transaction builder or server.
+
+The Subintent header is explicit input and includes network, epoch range, discriminator, and optional proposer timestamp bounds. Match it to the intended network. The CLI does not infer payer account details from x402 or HTTP context; the manifest and signature determine payer authorization.
+
+### Standalone Subintent Example
+
+\`subintent-header.json\`:
+
+\`\`\`json
+{
+  "type": "subintentHeader",
+  "version": 1,
+  "header": {
+    "networkId": 1,
+    "startEpochInclusive": 123,
+    "endEpochExclusive": 133,
+    "intentDiscriminator": 987654321
+  }
+}
+\`\`\`
+
+\`preview-root.rtm\`:
+
+\`\`\`rtm
+USE_CHILD NamedIntent("payment") Intent("<subintentHash>");
+YIELD_TO_CHILD NamedIntent("payment");
+\`\`\`
+
+Commands:
+
+\`\`\`sh
+rdx subintent prepare \\
+  --manifest ./payment-subintent.rtm \\
+  --header ./subintent-header.json \\
+  --root-manifest ./preview-root.rtm
+rdx subintent build \\
+  --prepared ./.rdx/subintents/subtxid_rdx1.../prepared-subintent.json \\
+  --signature ./payment-signature.json
+\`\`\`
+
+Use the \`subintentHash\` and generated signing request from prepare for out-of-band signing. Use the \`signedPartialTransactionHex\` from build as the portable signed Subintent payload.
+
 ## Command Examples
 
 \`\`\`sh
@@ -105,6 +164,9 @@ rdx tx notarize txid_example
 rdx tx submit txid_example
 rdx tx status txid_example
 rdx tx status txid_example --read-only
+rdx subintent prepare --manifest ./payment-subintent.rtm --header ./subintent-header.json --root-manifest ./preview-root.rtm
+rdx subintent prepare --manifest ./payment-subintent.rtm --header ./subintent-header.json --no-preview
+rdx subintent build --prepared ./.rdx/subintents/subtxid_rdx1.../prepared-subintent.json --signature ./payment-signature.json
 rdx tx path txid_example
 rdx tx list
 rdx tx list --pattern root.rtm

--- a/packages/cli/src/schemas.ts
+++ b/packages/cli/src/schemas.ts
@@ -146,6 +146,20 @@ export const SubintentsFileSchema = Schema.Struct({
   ),
 });
 
+export const SubintentHeaderFileSchema = Schema.Struct({
+  type: Schema.Literal('subintentHeader'),
+  version: Schema.Literal(1),
+  header: Schema.Struct({
+    networkId: Schema.Number,
+    startEpochInclusive: Schema.Number,
+    endEpochExclusive: Schema.Number,
+    intentDiscriminator: Schema.Number,
+    minProposerTimestampInclusive: Schema.optional(Schema.Number),
+    maxProposerTimestampExclusive: Schema.optional(Schema.Number),
+  }),
+  message: Schema.optional(Schema.String),
+});
+
 export const NotaryFileSchema = Schema.Struct({
   type: Schema.Literal('notary'),
   version: Schema.Literal(1),
@@ -182,6 +196,22 @@ export const PreparedTransactionSchema = Schema.Struct({
   authorizationAnalysis: AuthorizationAnalysisSchema,
   notaryPublicKey: Schema.optional(PublicKeySchema),
   notaryIsSignatory: Schema.optional(Schema.Boolean),
+});
+
+export const PreparedSubintentSchema = Schema.Struct({
+  type: Schema.Literal('preparedSubintent'),
+  version: Schema.Literal(1),
+  subintentHash: HashSchema,
+  networkId: Schema.Number,
+  manifestSourceFile: Schema.String,
+  headerSourceFile: Schema.String,
+  subintentPath: Schema.String,
+  subintentManifestPath: Schema.String,
+  subintentHeaderPath: Schema.String,
+  signingRequestPath: Schema.String,
+  signatureTemplatePath: Schema.String,
+  previewRootManifestPath: Schema.optional(Schema.String),
+  previewResultPath: Schema.String,
 });
 
 export const NetworkTransactionStatusSchema = Schema.Struct({
@@ -244,10 +274,12 @@ export type SignatureTemplate = typeof SignatureTemplateSchema.Type;
 export type SignatureEntry = typeof SignatureEntrySchema.Type;
 export type SignatureFile = typeof SignatureFileSchema.Type;
 export type SubintentsFile = typeof SubintentsFileSchema.Type;
+export type SubintentHeaderFile = typeof SubintentHeaderFileSchema.Type;
 export type NotaryFile = typeof NotaryFileSchema.Type;
 export type ArtifactStatus = typeof ArtifactStatusSchema.Type;
 export type AuthorizationAnalysis = typeof AuthorizationAnalysisSchema.Type;
 export type PreparedTransaction = typeof PreparedTransactionSchema.Type;
+export type PreparedSubintent = typeof PreparedSubintentSchema.Type;
 export type NetworkTransactionStatus =
   typeof NetworkTransactionStatusSchema.Type;
 export type SubmitResult = typeof SubmitResultSchema.Type;

--- a/packages/cli/src/subintent.test.ts
+++ b/packages/cli/src/subintent.test.ts
@@ -1,0 +1,165 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { it } from '@effect/vitest';
+import { Convert, RadixEngineToolkit } from '@steleaio/radix-engine-toolkit';
+import { Effect, Schema } from 'effect';
+import { describe, expect } from 'vitest';
+import {
+  PreparedSubintentSchema,
+  SignatureTemplateSchema,
+  SigningRequestSchema,
+} from './schemas';
+import {
+  buildSignedPartialTransaction,
+  prepareSubintentArtifacts,
+} from './subintent';
+import { makeTempDir } from './test-helpers';
+
+const manifest = 'YIELD_TO_PARENT;';
+const header = {
+  type: 'subintentHeader',
+  version: 1,
+  header: {
+    networkId: 1,
+    startEpochInclusive: 1,
+    endEpochExclusive: 10,
+    intentDiscriminator: 123,
+  },
+};
+const publicKeyHex =
+  '1111111111111111111111111111111111111111111111111111111111111111';
+const signatureHex =
+  '22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222';
+
+describe('subintent workflow', () => {
+  it.effect('prepares a standalone root subintent for signing', () =>
+    Effect.gen(function* () {
+      const cwd = yield* makeTempDir('subintent-prepare');
+      const artifactRoot = join(cwd, '.rdx', 'subintents');
+      const manifestPath = join(cwd, 'payment.rtm');
+      const headerPath = join(cwd, 'subintent-header.json');
+      const rootManifestPath = join(cwd, 'preview-root.rtm');
+      yield* Effect.promise(() => writeFile(manifestPath, manifest, 'utf8'));
+      yield* Effect.promise(() =>
+        writeFile(headerPath, JSON.stringify(header), 'utf8'),
+      );
+      yield* Effect.promise(() =>
+        writeFile(
+          rootManifestPath,
+          'USE_CHILD NamedIntent("payment") Intent("<subintentHash>");\nYIELD_TO_CHILD NamedIntent("payment");',
+          'utf8',
+        ),
+      );
+
+      const result = yield* prepareSubintentArtifacts({
+        artifactRoot,
+        manifestPath,
+        headerPath,
+        rootManifestPath,
+      });
+
+      const prepared = Schema.decodeUnknownSync(PreparedSubintentSchema)(
+        JSON.parse(
+          yield* Effect.promise(() => readFile(result.preparedPath, 'utf8')),
+        ),
+      );
+      expect(prepared.subintentHash.id).toMatch(/^subtxid_rdx1/);
+      expect(prepared.networkId).toBe(1);
+      expect(result.signatureTemplatePath).toBe(
+        join(result.artifactPath, 'signature-template.json'),
+      );
+
+      const request = Schema.decodeUnknownSync(SigningRequestSchema)(
+        JSON.parse(
+          yield* Effect.promise(() =>
+            readFile(join(result.artifactPath, 'signing-request.json'), 'utf8'),
+          ),
+        ),
+      );
+      expect(request.scope).toEqual({ kind: 'subintent', subintentId: 'root' });
+      expect(request.hash).toEqual(prepared.subintentHash);
+
+      const template = Schema.decodeUnknownSync(SignatureTemplateSchema)(
+        JSON.parse(
+          yield* Effect.promise(() =>
+            readFile(result.signatureTemplatePath, 'utf8'),
+          ),
+        ),
+      );
+      expect(template.hash).toEqual(prepared.subintentHash);
+
+      const previewRoot = yield* Effect.promise(() =>
+        readFile(join(result.artifactPath, 'preview-root.rtm'), 'utf8'),
+      );
+      expect(previewRoot).toContain(prepared.subintentHash.id);
+      expect(previewRoot).not.toContain('<subintentHash>');
+    }),
+  );
+
+  it.effect(
+    'builds signed partial transaction hex from a prepared subintent',
+    () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTempDir('subintent-build');
+        const artifactRoot = join(cwd, '.rdx', 'subintents');
+        const manifestPath = join(cwd, 'payment.rtm');
+        const headerPath = join(cwd, 'subintent-header.json');
+        yield* Effect.promise(() => writeFile(manifestPath, manifest, 'utf8'));
+        yield* Effect.promise(() =>
+          writeFile(headerPath, JSON.stringify(header), 'utf8'),
+        );
+
+        const prepared = yield* prepareSubintentArtifacts({
+          artifactRoot,
+          manifestPath,
+          headerPath,
+          noPreview: true,
+        });
+        const signaturePath = join(cwd, 'signature.json');
+        yield* Effect.promise(() =>
+          writeFile(
+            signaturePath,
+            JSON.stringify({
+              type: 'signatureFile',
+              version: 1,
+              transactionId: prepared.subintentHash.id,
+              signatures: [
+                {
+                  scope: { kind: 'subintent', subintentId: 'root' },
+                  account: null,
+                  hash: prepared.subintentHash,
+                  publicKey: { curve: 'Ed25519', hex: publicKeyHex },
+                  signature: { curve: 'Ed25519', hex: signatureHex },
+                },
+              ],
+            }),
+            'utf8',
+          ),
+        );
+
+        const result = yield* buildSignedPartialTransaction({
+          preparedPath: prepared.preparedPath,
+          signaturePath,
+        });
+
+        const hex = yield* Effect.promise(() =>
+          readFile(result.signedPartialTransactionPath, 'utf8'),
+        );
+        expect(hex).toBe(result.signedPartialTransactionHex);
+
+        const signedPartialTransaction = yield* Effect.promise(() =>
+          RadixEngineToolkit.SignedPartialTransactionV2.decompile(
+            Convert.HexString.toUint8Array(result.signedPartialTransactionHex),
+            1,
+          ),
+        );
+        expect(
+          signedPartialTransaction.partialTransaction.rootSubintent.intentCore
+            .header,
+        ).toEqual(header.header);
+        expect(signedPartialTransaction.rootSubintentSignatures).toHaveLength(
+          1,
+        );
+      }),
+  );
+});

--- a/packages/cli/src/subintent.ts
+++ b/packages/cli/src/subintent.ts
@@ -1,0 +1,345 @@
+import { basename, dirname, join } from 'node:path';
+import {
+  Convert,
+  RadixEngineToolkit,
+  SignatureWithPublicKey,
+  type SignedPartialTransactionV2,
+  type SubintentV2,
+} from '@steleaio/radix-engine-toolkit';
+import { Data, Effect, Schema } from 'effect';
+import { createTransactionArtifactDirectory } from './artifacts';
+import {
+  makeDirectory,
+  readFileString,
+  readJsonFile,
+  writeFileString,
+  writeJsonFile,
+} from './platformIo';
+import {
+  PLACEHOLDER_PUBLIC_KEY_HEX,
+  PLACEHOLDER_SIGNATURE_HEX,
+  type PreparedSubintent,
+  PreparedSubintentSchema,
+  type SignatureEntry,
+  SignatureFileSchema,
+  type SignatureTemplate,
+  type SigningRequest,
+  SubintentHeaderFileSchema,
+} from './schemas';
+
+const subintentHashPlaceholder = '<subintentHash>';
+
+export type PrepareSubintentResult = {
+  subintentHash: PreparedSubintent['subintentHash'];
+  artifactPath: string;
+  preparedPath: string;
+  signatureTemplatePath: string;
+  signingRequestPath: string;
+};
+
+export type BuildSignedPartialTransactionResult = {
+  subintentHash: PreparedSubintent['subintentHash'];
+  artifactPath: string;
+  signedPartialTransactionPath: string;
+  signedPartialTransactionHex: string;
+};
+
+export class SubintentPreviewRootManifestError extends Data.TaggedError(
+  'SubintentPreviewRootManifestError',
+)<{
+  placeholderCount: number;
+}> {}
+
+const writeJson = (path: string, value: unknown) =>
+  writeJsonFile(path, value, (reason) => reason);
+
+const writeWorkflowJson = (
+  artifactPath: string,
+  relativePath: string,
+  value: unknown,
+) =>
+  Effect.gen(function* () {
+    const path = join(artifactPath, relativePath);
+    yield* makeDirectory(
+      dirname(path),
+      { recursive: true },
+      (reason) => reason,
+    );
+    yield* writeJson(path, value);
+    return path;
+  });
+
+const messageFromHeaderFile = (
+  message: string | undefined,
+): SubintentV2['intentCore']['message'] =>
+  message === undefined
+    ? { kind: 'None' }
+    : {
+        kind: 'PlainText',
+        value: {
+          mimeType: 'text/plain',
+          message: {
+            kind: 'String',
+            value: message,
+          },
+        },
+      };
+
+const signatureEntryToRet = (entry: SignatureEntry) =>
+  new SignatureWithPublicKey.Ed25519(entry.signature.hex, entry.publicKey.hex);
+
+const buildRootSubintent = (input: {
+  manifest: string;
+  headerPath: string;
+}) =>
+  readJsonFile(input.headerPath, (reason) => reason).pipe(
+    Effect.flatMap(Schema.decodeUnknown(SubintentHeaderFileSchema)),
+    Effect.map(
+      (headerFile): SubintentV2 => ({
+        intentCore: {
+          header: headerFile.header,
+          instructions: input.manifest,
+          blobs: [],
+          message: messageFromHeaderFile(headerFile.message),
+          children: [],
+        },
+      }),
+    ),
+  );
+
+const writePreviewRootManifest = (input: {
+  artifactPath: string;
+  rootManifestPath: string | undefined;
+  subintentHashId: string | null;
+  noPreview: boolean | undefined;
+}) =>
+  Effect.gen(function* () {
+    if (input.rootManifestPath === undefined) {
+      const previewResultPath = yield* writeWorkflowJson(
+        input.artifactPath,
+        'preview-result.json',
+        {
+          type: 'subintentPreview',
+          version: 1,
+          status: input.noPreview ? 'skipped' : 'missing-root-manifest',
+        },
+      );
+      return {
+        previewRootManifestPath: undefined,
+        previewResultPath,
+      };
+    }
+
+    const rootManifest = yield* readFileString(
+      input.rootManifestPath,
+      (reason) => reason,
+    );
+    const placeholderCount =
+      rootManifest.split(subintentHashPlaceholder).length - 1;
+    if (placeholderCount !== 1) {
+      return yield* new SubintentPreviewRootManifestError({
+        placeholderCount,
+      });
+    }
+
+    const previewRootManifestPath = join(
+      input.artifactPath,
+      'preview-root.rtm',
+    );
+    yield* writeFileString(
+      previewRootManifestPath,
+      rootManifest.replace(
+        subintentHashPlaceholder,
+        input.subintentHashId ?? '',
+      ),
+      (reason) => reason,
+    );
+    const previewResultPath = yield* writeWorkflowJson(
+      input.artifactPath,
+      'preview-result.json',
+      {
+        type: 'subintentPreview',
+        version: 1,
+        status: 'prepared',
+      },
+    );
+
+    return {
+      previewRootManifestPath,
+      previewResultPath,
+    };
+  });
+
+export const prepareSubintentArtifacts = (input: {
+  artifactRoot: string;
+  manifestPath: string;
+  headerPath: string;
+  rootManifestPath?: string;
+  noPreview?: boolean;
+}): Effect.Effect<PrepareSubintentResult, unknown> =>
+  Effect.gen(function* () {
+    const manifest = yield* readFileString(
+      input.manifestPath,
+      (reason) => reason,
+    );
+    const rootSubintent = yield* buildRootSubintent({
+      manifest,
+      headerPath: input.headerPath,
+    });
+    const hash = yield* Effect.tryPromise(() =>
+      RadixEngineToolkit.SubintentV2.hash(rootSubintent),
+    );
+    yield* Effect.tryPromise(() =>
+      RadixEngineToolkit.SubintentV2.staticallyAnalyze(rootSubintent),
+    );
+
+    const subintentHash = {
+      id: hash.id,
+      hex: Convert.Uint8Array.toHexString(hash.hash),
+    };
+    const artifactPath = yield* createTransactionArtifactDirectory({
+      artifactRoot: input.artifactRoot,
+      transactionId: subintentHash.id ?? `subintent_${subintentHash.hex}`,
+    });
+    const { previewRootManifestPath, previewResultPath } =
+      yield* writePreviewRootManifest({
+        artifactPath,
+        rootManifestPath: input.rootManifestPath,
+        subintentHashId: subintentHash.id,
+        noPreview: input.noPreview,
+      });
+
+    const signingRequest: SigningRequest = {
+      type: 'signingRequest',
+      version: 1,
+      transactionId: subintentHash.id ?? subintentHash.hex,
+      scope: { kind: 'subintent', subintentId: 'root' },
+      account: null,
+      hash: subintentHash,
+      signingRequestPath: 'signing-request.json',
+    };
+    const signatureTemplate: SignatureTemplate = {
+      type: 'signatureTemplate',
+      version: 1,
+      transactionId: subintentHash.id ?? subintentHash.hex,
+      scope: { kind: 'subintent', subintentId: 'root' },
+      account: null,
+      hash: subintentHash,
+      signingRequestPath: 'signing-request.json',
+      publicKey: { curve: 'Ed25519', hex: PLACEHOLDER_PUBLIC_KEY_HEX },
+      signature: { curve: 'Ed25519', hex: PLACEHOLDER_SIGNATURE_HEX },
+    };
+    const prepared: PreparedSubintent = {
+      type: 'preparedSubintent',
+      version: 1,
+      subintentHash,
+      networkId: rootSubintent.intentCore.header.networkId,
+      manifestSourceFile: basename(input.manifestPath),
+      headerSourceFile: basename(input.headerPath),
+      subintentPath: 'subintent.json',
+      subintentManifestPath: 'subintent.rtm',
+      subintentHeaderPath: 'subintent-header.json',
+      signingRequestPath: 'signing-request.json',
+      signatureTemplatePath: 'signature-template.json',
+      previewRootManifestPath:
+        previewRootManifestPath === undefined
+          ? undefined
+          : basename(previewRootManifestPath),
+      previewResultPath: basename(previewResultPath),
+    };
+
+    yield* writeFileString(
+      join(artifactPath, 'subintent.rtm'),
+      manifest,
+      (reason) => reason,
+    );
+    yield* writeJson(join(artifactPath, 'subintent-header.json'), {
+      type: 'subintentHeader',
+      version: 1,
+      header: rootSubintent.intentCore.header,
+      message:
+        rootSubintent.intentCore.message.kind === 'PlainText'
+          ? rootSubintent.intentCore.message.value.message.value
+          : undefined,
+    });
+    yield* writeJson(join(artifactPath, 'subintent.json'), rootSubintent);
+    const signingRequestPath = yield* writeWorkflowJson(
+      artifactPath,
+      'signing-request.json',
+      signingRequest,
+    );
+    const signatureTemplatePath = yield* writeWorkflowJson(
+      artifactPath,
+      'signature-template.json',
+      signatureTemplate,
+    );
+    const preparedPath = join(artifactPath, 'prepared-subintent.json');
+    yield* writeJson(preparedPath, prepared);
+
+    return {
+      subintentHash,
+      artifactPath,
+      preparedPath,
+      signatureTemplatePath,
+      signingRequestPath,
+    };
+  });
+
+export const buildSignedPartialTransaction = (input: {
+  preparedPath: string;
+  signaturePath: string;
+}): Effect.Effect<BuildSignedPartialTransactionResult, unknown> =>
+  Effect.gen(function* () {
+    const artifactPath = dirname(input.preparedPath);
+    const prepared = yield* readJsonFile(
+      input.preparedPath,
+      (reason) => reason,
+    ).pipe(Effect.flatMap(Schema.decodeUnknown(PreparedSubintentSchema)));
+    const rootSubintent = yield* readJsonFile(
+      join(artifactPath, prepared.subintentPath),
+      (reason) => reason,
+    );
+    const signatureFile = yield* readJsonFile(
+      input.signaturePath,
+      (reason) => reason,
+    ).pipe(Effect.flatMap(Schema.decodeUnknown(SignatureFileSchema)));
+    const rootSignatures = signatureFile.signatures
+      .filter(
+        (entry) =>
+          entry.scope.kind === 'subintent' &&
+          entry.scope.subintentId === 'root' &&
+          entry.hash.hex === prepared.subintentHash.hex,
+      )
+      .map(signatureEntryToRet);
+    const signedPartialTransaction: SignedPartialTransactionV2 = {
+      partialTransaction: {
+        rootSubintent: yield* Schema.decodeUnknown(Schema.Any)(rootSubintent),
+        nonRootSubintents: [],
+      },
+      rootSubintentSignatures: rootSignatures,
+      nonRootSubintentSignatures: [],
+    };
+    const compiled = yield* Effect.tryPromise(() =>
+      RadixEngineToolkit.SignedPartialTransactionV2.compile(
+        signedPartialTransaction,
+      ),
+    );
+    const signedPartialTransactionHex =
+      Convert.Uint8Array.toHexString(compiled);
+    const signedPartialTransactionPath = join(
+      artifactPath,
+      'signed-partial-transaction.hex',
+    );
+    yield* writeFileString(
+      signedPartialTransactionPath,
+      signedPartialTransactionHex,
+      (reason) => reason,
+    );
+
+    return {
+      subintentHash: prepared.subintentHash,
+      artifactPath,
+      signedPartialTransactionPath,
+      signedPartialTransactionHex,
+    };
+  });

--- a/packages/tx-tool/src/compileTransaction.spec.ts
+++ b/packages/tx-tool/src/compileTransaction.spec.ts
@@ -1,15 +1,22 @@
 import { layer } from '@effect/vitest';
-import { PrivateKey } from '@steleaio/radix-engine-toolkit';
+import { PrivateKey, RadixEngineToolkit } from '@steleaio/radix-engine-toolkit';
 import { Effect, Layer, Redacted } from 'effect';
 import {
   Epoch,
   HexString,
   NetworkId,
   Nonce,
+  TransactionManifestString,
 } from '@radix-effects/shared';
 import { CompileTransaction } from './compileTransaction';
 import { faucet } from './manifests/faucet';
-import { TransactionHeaderSchema, TransactionHeaderV2Schema, TransactionIntentSchema, TransactionIntentV2Schema } from './schemas';
+import {
+  SubintentV2Schema,
+  TransactionHeaderSchema,
+  TransactionHeaderV2Schema,
+  TransactionIntentSchema,
+  TransactionIntentV2Schema,
+} from './schemas';
 import { Signer } from './signer/signer';
 import { createAccount } from './test-helpers/createAccount';
 
@@ -93,6 +100,73 @@ layer(testLayer)('CompileTransaction', (it) => {
       const compiled = yield* compileTransaction({
         intent,
         signatures: [],
+      });
+
+      expect(compiled).toBeInstanceOf(Uint8Array);
+      expect(compiled.length).toBeGreaterThan(0);
+    }),
+  );
+
+  it.effect('compiles v2 intents when root and subintent headers differ', () =>
+    Effect.gen(function* () {
+      const compileTransaction = yield* CompileTransaction;
+      const childSubintent = SubintentV2Schema.make({
+        intentCore: {
+          header: {
+            networkId: NetworkId.make(2),
+            startEpochInclusive: Epoch.make(2),
+            endEpochExclusive: Epoch.make(10),
+            minProposerTimestampInclusive: 1_700_000_000,
+            maxProposerTimestampExclusive: 1_700_000_600,
+            intentDiscriminator: 11,
+          },
+          instructions: TransactionManifestString.make('YIELD_TO_PARENT;'),
+          blobs: [],
+          message: { kind: 'None' as const },
+          children: [],
+        },
+      });
+      const childSubintentHash = yield* Effect.tryPromise(() =>
+        RadixEngineToolkit.SubintentV2.hash(childSubintent),
+      );
+      const rootManifest = TransactionManifestString.make(`
+        USE_CHILD
+          NamedIntent("payment")
+          Intent("${childSubintentHash.id}")
+        ;
+
+        YIELD_TO_CHILD
+          NamedIntent("payment")
+        ;
+      `);
+
+      const intent = TransactionIntentV2Schema.make({
+        transactionHeader: TransactionHeaderV2Schema.make({
+          notaryPublicKey,
+          notaryIsSignatory: false,
+          tipBasisPoints: 0,
+        }),
+        rootIntentCore: {
+          header: {
+            networkId: NetworkId.make(2),
+            startEpochInclusive: Epoch.make(1),
+            endEpochExclusive: Epoch.make(20),
+            minProposerTimestampInclusive: 1_699_999_900,
+            maxProposerTimestampExclusive: 1_700_001_000,
+            intentDiscriminator: 22,
+          },
+          instructions: rootManifest,
+          blobs: [],
+          message: { kind: 'None' as const },
+          children: [childSubintentHash.hash],
+        },
+        nonRootSubintents: [childSubintent],
+      });
+
+      const compiled = yield* compileTransaction({
+        intent,
+        signatures: [],
+        subintentSignatures: [[]],
       });
 
       expect(compiled).toBeInstanceOf(Uint8Array);

--- a/packages/tx-tool/src/compileTransaction.ts
+++ b/packages/tx-tool/src/compileTransaction.ts
@@ -1,3 +1,4 @@
+import { HexString } from '@radix-effects/shared';
 import {
   Convert,
   type NotarizedTransaction,
@@ -6,8 +7,7 @@ import {
   TransactionBuilder as RetTransactionBuilder,
   TransactionV2Builder as RetTransactionV2Builder,
 } from '@steleaio/radix-engine-toolkit';
-import { Data, Effect, pipe, Schema } from 'effect';
-import { HexString } from '@radix-effects/shared';
+import { Data, Effect, Schema, pipe } from 'effect';
 import { NotaryKeyPair } from './notaryKeyPair';
 import {
   Ed25519SignatureWithPublicKeySchema,
@@ -78,7 +78,7 @@ export class CompileTransaction extends Effect.Service<CompileTransaction>()(
             for (let i = 0; i < intent.nonRootSubintents.length; i++) {
               builderStep = builderStep.addSignedSubintent(
                 intent.nonRootSubintents[i],
-                input.subintentSignatures?.[i] ?? [],
+                [...(input.subintentSignatures?.[i] ?? [])],
               );
             }
 

--- a/packages/tx-tool/src/createTransactionIntent.spec.ts
+++ b/packages/tx-tool/src/createTransactionIntent.spec.ts
@@ -14,6 +14,7 @@ import {
 } from "effect";
 import {
   AccountAddress,
+  Epoch,
   HexString,
   NetworkId,
   TransactionManifestString,
@@ -119,7 +120,7 @@ describe("CreateTransactionIntent", () => {
   );
 
   it.live(
-    "should create, compile, submit, and poll a v2 transaction intent",
+    "should submit a v2 transaction when root and subintent headers differ",
     () =>
       Effect.gen(function* () {
         const createTransactionHeaderV2 = yield* TransactionHeaderV2;
@@ -158,6 +159,8 @@ describe("CreateTransactionIntent", () => {
             startEpochInclusive: Option.none(),
             endEpochExclusive: Option.none(),
           });
+        const currentEpoch = intentHeader.startEpochInclusive;
+        const currentTimestamp = Math.floor(Date.now() / 1000);
 
         const subintentInstructions = TransactionManifestString.make(`
           CALL_METHOD
@@ -186,6 +189,10 @@ describe("CreateTransactionIntent", () => {
           intentCore: {
             header: {
               ...intentHeader,
+              startEpochInclusive: Epoch.make(currentEpoch),
+              endEpochExclusive: Epoch.make(currentEpoch + 2),
+              minProposerTimestampInclusive: currentTimestamp - 300,
+              maxProposerTimestampExclusive: currentTimestamp + 3_600,
               intentDiscriminator: uniqueDiscriminator,
             },
             instructions: subintentInstructions,
@@ -235,8 +242,11 @@ describe("CreateTransactionIntent", () => {
           rootIntentCore: {
             header: {
               ...intentHeader,
+              startEpochInclusive: Epoch.make(Math.max(1, currentEpoch - 1)),
+              endEpochExclusive: Epoch.make(currentEpoch + 3),
+              minProposerTimestampInclusive: currentTimestamp - 600,
+              maxProposerTimestampExclusive: currentTimestamp + 7_200,
               intentDiscriminator: uniqueDiscriminator + 1,
-              
             },
             instructions: manifest,
             blobs: [],
@@ -246,9 +256,8 @@ describe("CreateTransactionIntent", () => {
           nonRootSubintents: [childSubintent],
         });
 
-
-
-        const staticallyAnalyzeManifestV2Result = yield* staticallyAnalyzeManifestV2({ intent });
+        const staticallyAnalyzeManifestV2Result =
+          yield* staticallyAnalyzeManifestV2({ intent });
         yield* Effect.log("Statically analyze manifest v2 result", {
           staticallyAnalyzeManifestV2Result: JSON.stringify(staticallyAnalyzeManifestV2Result, null, 2),
         });
@@ -301,7 +310,7 @@ describe("CreateTransactionIntent", () => {
             rootSignerPublicKeys: [],
             nonRootSubintentSignerPublicKeys: [[]],
           });
-          
+
         const compiledPreview = yield* Effect.tryPromise(() =>
           RadixEngineToolkit.PreviewTransactionV2.compile(previewTx),
         );
@@ -331,6 +340,7 @@ describe("CreateTransactionIntent", () => {
         const statusResult = yield* pollTransactionStatus.poll({ id });
 
         expect(statusResult).toBeDefined();
+        expect(statusResult.intent_status).toBe("CommittedSuccess");
       }).pipe(
         Effect.tapError(Effect.logError),
         Effect.provide(Logger.pretty),

--- a/packages/tx-tool/src/index.ts
+++ b/packages/tx-tool/src/index.ts
@@ -6,6 +6,7 @@ export * from './createTransactionIntent';
 export * from './createTransactionIntentV2';
 export * from './epoch';
 export * from './intentHash';
+export * from './inspectSignedPartialTransaction';
 export * from './notaryKeyPair';
 export * from './previewTransaction';
 export * from './staticallyAnalyzeManifest';

--- a/packages/tx-tool/src/inspectSignedPartialTransaction.spec.ts
+++ b/packages/tx-tool/src/inspectSignedPartialTransaction.spec.ts
@@ -1,0 +1,73 @@
+import {
+  Convert,
+  RadixEngineToolkit,
+  SignatureWithPublicKey,
+  type SignedPartialTransactionV2,
+  type SubintentV2,
+} from '@steleaio/radix-engine-toolkit';
+import { describe, expect, it } from 'vitest';
+import { inspectSignedPartialTransaction } from './inspectSignedPartialTransaction';
+
+const publicKeyHex =
+  '1111111111111111111111111111111111111111111111111111111111111111';
+const signatureHex =
+  '22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222';
+
+const rootSubintent = {
+  intentCore: {
+    header: {
+      networkId: 1,
+      startEpochInclusive: 1,
+      endEpochExclusive: 10,
+      intentDiscriminator: 123,
+    },
+    instructions: 'YIELD_TO_PARENT;',
+    blobs: [],
+    message: { kind: 'None' },
+    children: [],
+  },
+} satisfies SubintentV2;
+
+describe('Signed Partial Transaction Inspection', () => {
+  it('derives root subintent details from signed partial transaction bytes', async () => {
+    const signedPartialTransaction = {
+      partialTransaction: {
+        rootSubintent,
+        nonRootSubintents: [],
+      },
+      rootSubintentSignatures: [
+        new SignatureWithPublicKey.Ed25519(signatureHex, publicKeyHex),
+      ],
+      nonRootSubintentSignatures: [],
+    } satisfies SignedPartialTransactionV2;
+    const compiled = await RadixEngineToolkit.SignedPartialTransactionV2.compile(
+      signedPartialTransaction,
+    );
+    const expectedHash =
+      await RadixEngineToolkit.SubintentV2.hash(rootSubintent);
+
+    const inspection = await inspectSignedPartialTransaction({
+      networkId: 1,
+      signedPartialTransactionHex: Convert.Uint8Array.toHexString(compiled),
+    });
+
+    expect(inspection.rootSubintentHash).toEqual({
+      id: expectedHash.id,
+      hex: Convert.Uint8Array.toHexString(expectedHash.hash),
+    });
+    expect(inspection.rootSubintent.intentCore.header).toEqual(
+      rootSubintent.intentCore.header,
+    );
+    expect(inspection.rootSubintent.intentCore.instructions.trim()).toBe(
+      'YIELD_TO_PARENT;',
+    );
+    expect(inspection.rootSubintentSignatures).toEqual([
+      {
+        curve: 'Ed25519',
+        signature: signatureHex,
+        publicKey: publicKeyHex,
+      },
+    ]);
+    expect(inspection.nonRootSubintentCount).toBe(0);
+  });
+});

--- a/packages/tx-tool/src/inspectSignedPartialTransaction.ts
+++ b/packages/tx-tool/src/inspectSignedPartialTransaction.ts
@@ -1,0 +1,66 @@
+import {
+  Convert,
+  RadixEngineToolkit,
+  type SignedPartialTransactionV2,
+  type SubintentV2,
+} from '@steleaio/radix-engine-toolkit';
+
+export type InspectedSignature = {
+  curve: 'Ed25519';
+  signature: string;
+  publicKey: string;
+};
+
+export type SignedPartialTransactionInspection = {
+  signedPartialTransaction: SignedPartialTransactionV2;
+  rootSubintent: SubintentV2;
+  rootSubintentHash: {
+    id: string | null;
+    hex: string;
+  };
+  rootSubintentSignatures: InspectedSignature[];
+  nonRootSubintentCount: number;
+};
+
+const inspectSignature = (signature: {
+  curve: string;
+  signature: Uint8Array;
+  publicKey: Uint8Array | undefined;
+}): InspectedSignature => {
+  if (signature.curve !== 'Ed25519' || signature.publicKey === undefined) {
+    throw new Error('Only Ed25519 signatures with public keys are supported');
+  }
+
+  return {
+    curve: 'Ed25519',
+    signature: Convert.Uint8Array.toHexString(signature.signature),
+    publicKey: Convert.Uint8Array.toHexString(signature.publicKey),
+  };
+};
+
+export const inspectSignedPartialTransaction = async (input: {
+  signedPartialTransactionHex: string;
+  networkId: number;
+}): Promise<SignedPartialTransactionInspection> => {
+  const signedPartialTransaction =
+    await RadixEngineToolkit.SignedPartialTransactionV2.decompile(
+      Convert.HexString.toUint8Array(input.signedPartialTransactionHex),
+      input.networkId,
+    );
+  const rootSubintent =
+    signedPartialTransaction.partialTransaction.rootSubintent;
+  const hash = await RadixEngineToolkit.SubintentV2.hash(rootSubintent);
+
+  return {
+    signedPartialTransaction,
+    rootSubintent,
+    rootSubintentHash: {
+      id: hash.id,
+      hex: Convert.Uint8Array.toHexString(hash.hash),
+    },
+    rootSubintentSignatures:
+      signedPartialTransaction.rootSubintentSignatures.map(inspectSignature),
+    nonRootSubintentCount:
+      signedPartialTransaction.partialTransaction.nonRootSubintents.length,
+  };
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,7 +76,7 @@ catalogs:
       specifier: ^8.0.2
       version: 8.3.5
     tsx:
-      specifier: ^4.7.1
+      specifier: 4.19.2
       version: 4.19.2
     typescript:
       specifier: ^5.3.3
@@ -147,6 +147,34 @@ importers:
       typescript:
         specifier: ~5.6.2
         version: 5.6.3
+
+  examples/x402:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^2.0.4
+        version: 2.0.4(hono@4.12.23)
+      '@radix-effects/tx-tool':
+        specifier: workspace:*
+        version: link:../../packages/tx-tool
+      effect:
+        specifier: 'catalog:'
+        version: 3.19.19
+      hono:
+        specifier: ^4.12.23
+        version: 4.12.23
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.10.2
+      tsx:
+        specifier: 'catalog:'
+        version: 4.19.2
+      typescript:
+        specifier: 'catalog:'
+        version: 5.6.3
+      vitest:
+        specifier: 'catalog:'
+        version: 1.6.0(@types/node@22.10.2)(terser@5.37.0)
 
   packages/agent-toolkit:
     dependencies:
@@ -2248,6 +2276,12 @@ packages:
 
   '@hapi/topo@5.1.0':
     resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
+
+  '@hono/node-server@2.0.4':
+    resolution: {integrity: sha512-Ut3y0dMMPWy6bZ2kVfx25EOVbZlm15dhF4mOsezMlhpNHy+4MkU1qN9Y6lnruYi4wPmFzimGX2X7LF/FwHli4A==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      hono: ^4
 
   '@inquirer/external-editor@1.0.3':
     resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
@@ -4626,6 +4660,10 @@ packages:
 
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
+
+  hono@4.12.23:
+    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
+    engines: {node: '>=16.9.0'}
 
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
@@ -10108,6 +10146,10 @@ snapshots:
     dependencies:
       '@hapi/hoek': 9.3.0
 
+  '@hono/node-server@2.0.4(hono@4.12.23)':
+    dependencies:
+      hono: 4.12.23
+
   '@inquirer/external-editor@1.0.3(@types/node@22.13.10)':
     dependencies:
       chardet: 2.1.1
@@ -12793,6 +12835,8 @@ snapshots:
   hoist-non-react-statics@3.3.2:
     dependencies:
       react-is: 16.13.1
+
+  hono@4.12.23: {}
 
   hookable@5.5.3: {}
 


### PR DESCRIPTION
## Why

x402 needs a concrete Radix reference design for the `exact` scheme which can protect an HTTP resource without making the resource server know payer account details up front.

On Radix, that maps naturally to a payer-signed Subintent: the client signs only the payment intent, while the server wraps that signed partial transaction in a sponsored root transaction, submits it, and waits for `CommittedSuccess` before serving the protected resource.

This PR also keeps the payer side generic. There is no x402-specific agent client here; the client-facing capability is the generic `rdx subintent` workflow.

## What

- Add generic `rdx subintent prepare/build` support for standalone signed partial transactions.
- Add a tx-tool helper for inspecting signed partial transactions and deriving Subintent details.
- Add `examples/x402` as a runnable Hono reference server for a protected markdown resource.
- Implement exact Radix x402 payment requirements, payload parsing, Subintent validation, in-memory settlement caching, and sponsored settlement boundaries.
- Add local docs and context for the x402 Radix reference design.

## Data Flow

```mermaid
sequenceDiagram
    participant Client as Client / Agent
    participant CLI as rdx subintent
    participant Server as Hono x402 middleware
    participant Cache as Settlement cache
    participant Facilitator as Settlement facilitator
    participant Gateway as Radix Gateway / Network
    participant Resource as Protected markdown

    Client->>Server: GET /protected/reference.md
    Server-->>Client: 402 Payment Required + exact Radix paymentRequirements

    Client->>CLI: prepare Subintent from payment manifest + header
    CLI-->>Client: signing request / Subintent hash
    Client->>CLI: build signed partial transaction from signature
    CLI-->>Client: signedPartialTransaction

    Client->>Server: GET /protected/reference.md + X-PAYMENT
    Server->>Server: parse x402 payment payload
    Server->>Server: inspect signed partial transaction
    Server->>Server: validate exact amount, asset, recipient, network, resource
    Server->>Cache: lookup subintentHash + paymentRequirementsHash + resourceUrl

    alt cached CommittedSuccess
        Cache-->>Server: settlement found
    else not cached
        Server->>Facilitator: settle signed Subintent
        Facilitator->>Gateway: preview sponsored root transaction
        Gateway-->>Facilitator: preview accepted
        Facilitator->>Gateway: submit sponsored root transaction
        Gateway-->>Facilitator: transaction status
        Facilitator->>Gateway: poll until CommittedSuccess
        Facilitator-->>Server: CommittedSuccess
        Server->>Cache: store settlement result
    end

    Server->>Resource: read markdown file
    Resource-->>Server: markdown
    Server-->>Client: 200 text/markdown
```

## Notes

- Payer-side behavior stays generic: the client creates/signs a Subintent through `rdx subintent`; there is no x402-specific agent client in this PR.
- The example uses Mainnet configuration placeholders and rejects unresolved placeholders at runtime.
- Settlement waits for `CommittedSuccess`; the runnable server supports a mock settlement backend for local smoke testing.
- The in-memory cache key is `subintentHash + paymentRequirementsHash + resourceUrl`.

## Tests

- `pnpm --filter @radix-effects/x402-example exec vitest run`
- `pnpm --filter @radix-effects/x402-example run check-types`
- `pnpm --filter rdx-cli exec vitest run src/subintent.test.ts src/cli.test.ts`
- `pnpm --filter rdx-cli run check-types`
- `pnpm --filter @radix-effects/tx-tool exec vitest run src/inspectSignedPartialTransaction.spec.ts src/compileTransaction.spec.ts src/createTransactionIntent.spec.ts`
- `pnpm --filter @radix-effects/tx-tool run check-types`
- `pnpm --filter @radix-effects/tx-tool run build`
- Smoke: `X402_MOCK_SETTLEMENT=true PORT=4021 pnpm --filter @radix-effects/x402-example run server`, then protected route returns HTTP 402 with exact Radix requirements.